### PR TITLE
Update Adsense slot IDs with actual values

### DIFF
--- a/src/components/widget/SideBar.astro
+++ b/src/components/widget/SideBar.astro
@@ -20,7 +20,7 @@ const className = Astro.props.class;
         {/* Sidebar AdSense ad - for desktop monetization */}
         <div class="onload-animation" style="animation-delay: 100ms">
             <AdSense 
-                slot="sidebar-ad" 
+                slot="3731319495" 
                 className="rounded-lg"
                 format="rectangle"
                 layout="display"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -171,7 +171,7 @@ const bannerOffset =
 		<!-- Mobile sticky AdSense ad - bottom of screen on mobile devices -->
 		<div class="adsense-mobile-sticky md:hidden">
 			<AdSense 
-				slot="mobile-sticky-ad" 
+				slot="8792074484" 
 				className="fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800"
 				format="anchor"
 				layout="display"

--- a/src/pages/[lang]/posts/[...slug].astro
+++ b/src/pages/[lang]/posts/[...slug].astro
@@ -115,7 +115,7 @@ const jsonLd = {
             {/* In-article AdSense ad - placed after content for better CTR */}
             <div class="my-8 text-center">
                 <AdSense 
-                    slot="in-article-ad" 
+                    slot="2009902076" 
                     className="rounded-lg mx-auto"
                     format="fluid"
                     layout="in-article"
@@ -129,7 +129,7 @@ const jsonLd = {
             {/* Below-content AdSense ad - for additional monetization */}
             <div class="my-8 text-center">
                 <AdSense 
-                    slot="below-content-ad" 
+                    slot="5725785808" 
                     className="rounded-lg mx-auto"
                     format="horizontal"
                     layout="display"


### PR DESCRIPTION
## Update Adsense Slot IDs for Production

This PR updates all 4 Adsense ad placements with actual slot IDs for production monetization.

### Slot IDs Updated:
1. **In-article ad:** `2009902076` (after post content)
2. **Below content ad:** `5725785808` (before navigation)
3. **Sidebar ad:** `3731319495` (desktop sidebar)
4. **Mobile ad:** `8792074484` (mobile sticky bottom)

### Files Updated:
- `src/pages/[lang]/posts/[...slug].astro` - Updated 2 slot IDs
- `src/components/widget/SideBar.astro` - Updated 1 slot ID
- `src/layouts/Layout.astro` - Updated 1 slot ID

### Impact:
- Ads will start showing immediately after deployment
- Revenue generation begins
- All ad placements are now production-ready

### Ready to:
1. Merge this PR
2. Deploy to production
3. Start earning Adsense revenue

**Note:** Previous PR #58 was already merged with the blog post and ad placements. This PR only updates the slot IDs.