### PR TITLE
Add Vietnamese translations for all blog posts (65 new files)

### DIFF
--- a/src/content/posts/Self-host-ArchiveBox-ArchiveBox-vi.md
+++ b/src/content/posts/Self-host-ArchiveBox-ArchiveBox-vi.md
@@ -1,0 +1,113 @@
+---
+lang: vi
+title: "ArchiveBox/ArchiveBox: Giải Pháp Lưu Trữ Web Tự Lưu Trữ Tối Ưu"
+description: "Khám phá ArchiveBox/ArchiveBox, công cụ mã nguồn mở tự lưu trữ để lưu trữ nội dung web, bao gồm HTML, PDF, phương tiện và hơn thế nữa. Hoàn hảo cho việc bảo quản dữ liệu."
+published: 2025-09-14
+tags: ['open-source', 'self-host', 'web-archiving', 'docker', 'python', 'data-preservation']
+category: Self-hosted
+author: minhpt
+---
+
+# ArchiveBox/ArchiveBox - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/ArchiveBox/ArchiveBox](https://github.com/ArchiveBox/ArchiveBox)
+- **Sao:** 24824
+
+## 2. Mô Tả Dự Án
+ArchiveBox là một công cụ lưu trữ web mạnh mẽ, mã nguồn mở, tự lưu trữ được thiết kế để bảo quản nội dung web trong thời gian dài. Nó cho phép người dùng nhập URL, lịch sử trình duyệt, dấu trang hoặc dữ liệu từ các dịch vụ như Pocket và Pinboard, và lưu lại một bản chụp toàn diện bao gồm HTML, JavaScript, PDF, hình ảnh, video và các phương tiện khác. ArchiveBox đảm bảo bạn có một bản sao nội dung web cục bộ, có thể truy cập được, bảo vệ khỏi link rot và xóa nội dung.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+ArchiveBox là giải pháp thay thế mạnh mẽ cho nhiều giải pháp lưu trữ thương mại và mã nguồn mở, bao gồm:
+- Các dịch vụ thương mại như Archive.today và Perma.cc.
+- Các công cụ lưu dựa trên trình duyệt như SingleFile hay Save Page WE.
+- Các dịch vụ đánh dấu trang đám mây với khả năng lưu trữ hạn chế, như Pocket (phiên bản miễn phí) hoặc Evernote.
+- Các tùy chọn tự lưu trữ khác như Wallabag, mặc dù ArchiveBox hỗ trợ nhiều định dạng phương tiện và phạm vi rộng hơn.
+
+## 4. Chức Năng Chính
+ArchiveBox nổi bật với các tính năng chính sau:
+- **Lưu trữ đa định dạng:** Lưu nội dung ở nhiều định dạng, bao gồm WARC, PDF, ảnh chụp màn hình, DOM và tệp phương tiện.
+- **Hỗ trợ đầu vào đa dạng:** Chấp nhận URL từ lịch sử trình duyệt, dấu trang, Pocket, Pinboard và hơn thế nữa.
+- **Tự lưu trữ và Truy cập Ngoại tuyến:** Tất cả dữ liệu được lưu trữ cục bộ, đảm bảo quyền riêng tư và khả năng truy cập mà không phụ thuộc vào internet.
+- **Lưu trữ Theo lịch và Tăng dần:** Cho phép lưu trữ tự động, định kỳ và cập nhật các kho lưu trữ hiện có.
+- **Giao diện Tìm kiếm và Duyệt:** Cung cấp giao diện web thân thiện để tìm kiếm, xem và quản lý nội dung đã lưu trữ.
+- **Khả năng Mở rộng:** Hỗ trợ plugin và các phương pháp lưu trữ tùy chỉnh cho các trường hợp sử dụng cụ thể.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Mã nguồn mở và Miễn phí:** Không có chi phí bản quyền, với sự minh bạch và hỗ trợ cộng đồng đầy đủ.
+- **Lưu trữ Toàn diện:** Chụp được nhiều loại nội dung vượt xa HTML đơn thuần.
+- **Quyền riêng tư khi Tự lưu trữ:** Dữ liệu người dùng vẫn được giữ riêng tư và dưới sự kiểm soát của họ.
+- **Phát triển Tích cực:** Các bản cập nhật thường xuyên và cộng đồng ngày càng phát triển đảm bảo cải tiến liên tục.
+- **Tương thích Đa nền tảng:** Hoạt động trên Linux, macOS và Windows, với hỗ trợ Docker giúp đơn giản hóa việc triển khai.
+
+**Nhược điểm:**
+- **Tốn nhiều Tài nguyên:** Lưu trữ số lượng lớn URL có thể yêu cầu dung lượng lưu trữ và sức mạnh xử lý đáng kể.
+- **Đường cong Học tập Dốc:** Thiết lập và cấu hình ban đầu có thể khó khăn đối với người dùng không chuyên về kỹ thuật.
+- **Phụ thuộc vào Công cụ Bên ngoài:** Dựa vào các công cụ như Chromium, wget và các công cụ khác, có thể cần bảo trì.
+- **Lưu trữ Thời gian thực Hạn chế:** Thích hợp nhất cho nhu cầu lưu trữ theo lịch thay vì tức thời.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai ArchiveBox trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Ubuntu 20.04 trở lên.
+- Docker và Docker Compose đã được cài đặt.
+- Python 3.8+ (tùy chọn, cho thiết lập không dùng Docker).
+
+### Cài đặt Từng bước với Docker (Khuyến nghị):
+1. **Cập nhật Gói Hệ thống:**
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   ```
+
+2. **Cài đặt Docker và Docker Compose:**
+   ```bash
+   sudo apt install docker.io docker-compose -y
+   sudo systemctl enable docker && sudo systemctl start docker
+   ```
+
+3. **Tạo Thư mục cho ArchiveBox:**
+   ```bash
+   mkdir ~/archivebox && cd ~/archivebox
+   ```
+
+4. **Tải Tệp Docker Compose:**
+   ```bash
+   curl -O https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/master/docker-compose.yml
+   ```
+
+5. **Khởi tạo và Khởi động ArchiveBox:**
+   ```bash
+   docker-compose run archivebox init --setup
+   docker-compose up -d
+   ```
+
+6. **Truy cập Giao diện Web:**
+   Mở trình duyệt và điều hướng đến `http://your-server-ip:8000` để truy cập giao diện ArchiveBox.
+
+### Thêm URL vào Archive:
+- Sử dụng giao diện web để thêm URL thủ công.
+- Hoặc sử dụng dòng lệnh:
+  ```bash
+  docker-compose run archivebox add 'https://example.com'
+  ```
+
+### Tùy chọn: Cài đặt Không dùng Docker (Nâng cao):
+Nếu bạn muốn thiết lập không dùng Docker, hãy đảm bảo Python 3.8+ đã được cài đặt, sau đó:
+```bash
+sudo apt install python3-pip python3-venv -y
+python3 -m venv archivebox-env
+source archivebox-env/bin/activate
+pip install archivebox
+archivebox init
+archivebox manage createsuperuser
+archivebox server 0.0.0.0:8000
+```
+
+### Mẹo Bảo trì:
+- Cập nhật ArchiveBox thường xuyên: `docker-compose pull && docker-compose up -d`.
+- Theo dõi dung lượng lưu trữ, vì kho lưu trữ có thể phát triển nhanh chóng.
+- Sao lưu thư mục dữ liệu định kỳ.
+
+Để biết thêm chi tiết, hãy tham khảo [tài liệu chính thức của ArchiveBox](https://github.com/ArchiveBox/ArchiveBox/wiki).

--- a/src/content/posts/Self-host-HeyPuter-puter-vi.md
+++ b/src/content/posts/Self-host-HeyPuter-puter-vi.md
@@ -1,0 +1,139 @@
+---
+lang: vi
+title: "HeyPuter/puter: Hệ Điều Hành Internet Mã Nguồn Mở Tối Ưu Cho Tự Lưu Trữ"
+description: "Khám phá HeyPuter/puter, một Hệ điều hành Internet miễn phí, mã nguồn mở với hơn 35K sao GitHub. Tìm hiểu các tính năng, ưu nhược điểm và cách tự lưu trữ trên Ubuntu."
+published: 2025-09-04
+tags: ['open-source', 'self-host', 'web-os', 'javascript', 'docker', 'cloud-computing']
+category: Self-hosted
+author: minhpt
+---
+
+# HeyPuter/puter - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/HeyPuter/puter](https://github.com/HeyPuter/puter)
+- **Sao:** 35629
+
+## 2. Mô Tả Dự Án
+
+HeyPuter/puter là một dự án mã nguồn mở đầy tham vọng tự xưng là "Hệ Điều Hành Internet." Nó cung cấp một môi trường hệ điều hành miễn phí, có thể tự lưu trữ, chạy trực tiếp trong trình duyệt web của bạn. Bằng cách kết hợp sự quen thuộc của giao diện máy tính truyền thống với các công nghệ web hiện đại, Puter cung cấp một nền tảng linh hoạt cho việc triển khai ứng dụng, quản lý tệp và làm việc cộng tác—tất cả đều có thể truy cập từ bất kỳ thiết bị nào có trình duyệt. Kiến trúc của nó nhấn mạnh quyền riêng tư, khả năng kiểm soát của người dùng và khả năng mở rộng, khiến nó trở thành một lựa chọn thay thế hấp dẫn cho các giải pháp đám mây độc quyền.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Puter có thể thay thế cho một số loại phần mềm, bao gồm:
+
+- **Nền tảng Lưu trữ Đám mây & Cộng tác:** Google Drive, Dropbox và OneDrive.
+- **Giải pháp Máy tính Từ xa & VDI:** Windows Remote Desktop, Citrix Virtual Apps.
+- **IDE & Môi trường Phát triển Dựa trên Web:** CodeSandbox, Glitch và Replit.
+- **Bộ Ứng dụng Văn phòng:** Google Workspace và Microsoft 365 cho việc chỉnh sửa tài liệu và cộng tác cơ bản.
+
+## 4. Chức Năng Chính
+
+Chức năng cốt lõi của Puter xoay quanh việc cung cấp trải nghiệm hệ điều hành toàn diện dựa trên trình duyệt. Các tính năng chính bao gồm:
+
+- **Quản lý Tệp:** Trình khám phá tệp đồ họa hỗ trợ tải lên, tải xuống và sắp xếp.
+- **Hệ sinh thái Ứng dụng:** Các ứng dụng tích hợp sẵn như trình soạn thảo văn bản, trình xem ảnh và terminal, với hỗ trợ tích hợp ứng dụng bên thứ ba.
+- **Đa Nhiệm:** Quản lý cửa sổ, cho phép người dùng chạy nhiều ứng dụng cùng lúc.
+- **Tự Lưu trữ & Tùy chỉnh:** Toàn quyền kiểm soát việc triển khai, lưu trữ dữ liệu và sửa đổi giao diện.
+- **Công cụ Cộng tác:** Chỉnh sửa tài liệu thời gian thực và khả năng chia sẻ tệp.
+- **Khả năng Mở rộng:** API và SDK cho các nhà phát triển để xây dựng và tích hợp các ứng dụng tùy chỉnh.
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+
+- **Mã nguồn mở & Miễn phí:** Không có chi phí bản quyền, với toàn quyền truy cập mã nguồn.
+- **Có thể Tự lưu trữ:** Người dùng giữ toàn quyền kiểm soát dữ liệu và cơ sở hạ tầng.
+- **Đa nền tảng:** Chạy trên bất kỳ thiết bị nào có trình duyệt web hiện đại.
+- **Có thể Mở rộng:** Các nhà phát triển có thể tạo và tích hợp các ứng dụng tùy chỉnh một cách dễ dàng.
+- **Cộng đồng Tích cực:** Sự hiện diện mạnh mẽ trên GitHub với các bản cập nhật và đóng góp thường xuyên.
+
+**Nhược điểm:**
+
+- **Độ phức tạp khi Tự lưu trữ:** Yêu cầu kiến thức kỹ thuật để triển khai và bảo trì.
+- **Hiệu suất Ứng dụng Gốc Hạn chế:** Các ứng dụng nặng có thể không hoạt động tốt như phần mềm máy tính gốc.
+- **Giai đoạn Đầu:** Một số tính năng có thể vẫn đang được phát triển hoặc thiếu độ trau chuốt so với các lựa chọn thương mại.
+- **Phụ thuộc vào Trình duyệt:** Hiệu suất và khả năng tương thích có thể khác nhau giữa các trình duyệt khác nhau.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Hướng dẫn này sẽ hướng dẫn bạn triển khai Puter trên máy chủ Ubuntu 22.04 LTS. Quy trình sử dụng Docker để đơn giản hóa việc quản lý phụ thuộc.
+
+**Yêu cầu:**
+
+- Máy chủ Ubuntu 22.04 LTS với người dùng sudo không phải root.
+- Docker và Docker Compose đã được cài đặt.
+- Có kiến thức cơ bản về dòng lệnh.
+
+**Bước 1: Cập nhật Hệ thống và Cài đặt Docker**
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker --now
+```
+
+**Bước 2: Sao chép Kho lưu trữ**
+
+```bash
+git clone https://github.com/HeyPuter/puter.git
+cd puter
+```
+
+**Bước 3: Cấu hình Biến Môi trường**
+Tạo một tệp `.env` trong thư mục gốc của dự án và tùy chỉnh các biến sau (điều chỉnh khi cần):
+
+```plaintext
+PORT=3000
+DB_PATH=./data/db
+```
+
+**Bước 4: Xây dựng và Khởi động với Docker Compose**
+Chạy lệnh sau để xây dựng và khởi động các dịch vụ:
+
+```bash
+docker-compose up -d
+```
+
+**Bước 5: Xác minh Triển khai**
+Kiểm tra xem container có đang chạy không:
+
+```bash
+docker ps
+```
+
+Truy cập Puter bằng cách điều hướng đến `http://your-server-ip:3000` trong trình duyệt web của bạn.
+
+**Bước 6: (Tùy chọn) Thiết lập Reverse Proxy với Nginx**
+Để sử dụng trong sản xuất, hãy thiết lập Nginx làm reverse proxy:
+
+1. Cài đặt Nginx:
+
+   ```bash
+   sudo apt install nginx -y
+   ```
+
+2. Tạo tệp cấu hình mới tại `/etc/nginx/sites-available/puter`:
+
+   ```nginx
+   server {
+       listen 80;
+       server_name your-domain.com;
+
+       location / {
+           proxy_pass http://localhost:3000;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+       }
+   }
+   ```
+
+3. Kích hoạt cấu hình và khởi động lại Nginx:
+
+   ```bash
+   sudo ln -s /etc/nginx/sites-available/puter /etc/nginx/sites-enabled/
+   sudo nginx -t && sudo systemctl restart nginx
+   ```
+
+Phiên bản Puter tự lưu trữ của bạn hiện đã hoạt động và có thể truy cập được! Để biết thêm tùy chỉnh, hãy tham khảo [tài liệu chính thức](https://github.com/HeyPuter/puter).

--- a/src/content/posts/Self-host-Lissy93-dashy-vi.md
+++ b/src/content/posts/Self-host-Lissy93-dashy-vi.md
@@ -1,0 +1,106 @@
+---
+lang: vi
+title: "Lissy93/dashy: Bảng Điều Khiển Cá Nhân Tự Lưu Trữ Tối Ưu - Đánh Giá & Hướng Dẫn Thiết Lập"
+description: "Khám phá Lissy93/dashy, một bảng điều khiển cá nhân mã nguồn mở mạnh mẽ với widget, chủ đề và giám sát trạng thái. Hoàn hảo cho những người đam mê tự lưu trữ."
+published: 2025-09-16
+tags: ['open-source', 'self-host', 'dashboard', 'docker', 'javascript', 'vuejs', 'web-app']
+category: Self-hosted
+author: minhpt
+---
+
+# Lissy93/dashy - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/Lissy93/dashy](https://github.com/Lissy93/dashy)
+- **Sao:** 22311
+
+## 2. Mô Tả Dự Án
+Lissy93/dashy là một bảng điều khiển cá nhân giàu tính năng, tự lưu trữ được thiết kế để tập trung các dịch vụ web, ứng dụng và công cụ được sử dụng nhiều nhất của bạn vào một giao diện duy nhất, có thể tùy chỉnh. Nó cung cấp giao diện người dùng hiện đại, sạch sẽ với hỗ trợ widget, kiểm tra trạng thái, nhiều chủ đề và trình chỉnh sửa giao diện trực quan, khiến nó trở thành giải pháp lý tưởng cho cả sử dụng cá nhân và chuyên nghiệp để hợp lý hóa quy trình làm việc hàng ngày.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Dashy có thể là lựa chọn thay thế cho một số giải pháp bảng điều khiển thương mại và mã nguồn mở, bao gồm:
+- Heimdall
+- Organizr
+- Homer
+- Các sản phẩm thương mại như My Dashboard hoặc trang chủ cá nhân từ các nhà cung cấp trình duyệt
+
+## 4. Chức Năng Chính
+Các tính năng chính của Dashy bao gồm:
+- **Hệ thống Widget:** Thêm và tùy chỉnh widget cho thời tiết, ghi chú, nguồn cấp RSS và hơn thế nữa.
+- **Giám sát Trạng thái:** Kiểm tra thời gian hoạt động và trạng thái của các dịch vụ và ứng dụng của bạn.
+- **Tùy chỉnh Chủ đề:** Chọn từ nhiều chủ đề tích hợp sẵn hoặc tạo chủ đề của riêng bạn.
+- **Bộ Biểu tượng:** Thư viện biểu tượng phong phú để cá nhân hóa bảng điều khiển của bạn.
+- **Trình chỉnh sửa Giao diện:** Giao diện kéo và thả để sắp xếp các phần và thành phần.
+- **Hỗ trợ Nhiều Người dùng:** Cấu hình quyền truy cập cho các người dùng khác nhau với các quyền hạn khác nhau.
+- **Tích hợp Tìm kiếm:** Nhanh chóng tìm và truy cập các ứng dụng và dấu trang của bạn.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Khả năng tùy chỉnh cao với bộ tính năng phong phú.
+- Mã nguồn mở và miễn phí sử dụng.
+- Phát triển tích cực và hỗ trợ cộng đồng mạnh mẽ.
+- Dễ dàng triển khai bằng Docker hoặc các phương pháp truyền thống.
+- Thiết kế đáp ứng hoạt động trên cả máy tính và thiết bị di động.
+
+**Nhược điểm:**
+- Có thể có đường cong học tập đối với người dùng không chuyên về kỹ thuật.
+- Tự lưu trữ yêu cầu kỹ năng quản lý máy chủ cơ bản.
+- Một số tính năng nâng cao có thể yêu cầu cấu hình ngoài giao diện.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai Dashy trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Máy chủ chạy Ubuntu 20.04 trở lên.
+- Docker và Docker Compose đã được cài đặt.
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker --now
+```
+
+### Bước 2: Tạo Thư mục cho Dashy
+```bash
+mkdir ~/dashy && cd ~/dashy
+```
+
+### Bước 3: Tạo Tệp Docker Compose
+Tạo một tệp `docker-compose.yml` với nội dung sau:
+```yaml
+version: '3.8'
+services:
+  dashy:
+    image: lissy93/dashy
+    container_name: dashy
+    ports:
+      - 4000:80
+    volumes:
+      - ./conf.yml:/app/public/conf.yml
+    restart: unless-stopped
+```
+
+### Bước 4: Tạo Tệp Cấu hình
+Tạo một tệp `conf.yml` cơ bản:
+```yaml
+pageInfo:
+  title: My Dashboard
+sections:
+  - name: Welcome
+    items:
+      - title: GitHub
+        description: Code Repository
+        icon: fab fa-github
+        url: https://github.com
+```
+
+### Bước 5: Triển khai Dashy
+```bash
+docker-compose up -d
+```
+
+### Bước 6: Truy cập Bảng Điều Khiển của Bạn
+Mở trình duyệt và điều hướng đến `http://your-server-ip:4000`. Bạn sẽ thấy bảng điều khiển Dashy mới của mình. Tùy chỉnh thêm bằng cách chỉnh sửa `conf.yml` và khởi động lại container với `docker-compose restart`.
+
+Để biết thêm các tùy chọn cấu hình, hãy tham khảo [tài liệu chính thức](https://dashy.to/docs/).

--- a/src/content/posts/Self-host-LizardByte-Sunshine-vi.md
+++ b/src/content/posts/Self-host-LizardByte-Sunshine-vi.md
@@ -1,0 +1,114 @@
+---
+lang: vi
+title: "LizardByte/Sunshine: Giải Pháp Phát Trực Tiếp Game Tự Lưu Trữ Tối Ưu"
+description: "Khám phá LizardByte/Sunshine, máy chủ phát trực tiếp game mã nguồn mở thay thế các dịch vụ độc quyền. Tìm hiểu cách cài đặt, tính năng và lợi ích."
+published: 2025-09-11
+tags: ['open-source', 'self-host', 'game-streaming', 'moonlight', 'c-plus-plus', 'linux']
+category: Self-hosted
+author: minhpt
+---
+
+# LizardByte/Sunshine - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/LizardByte/Sunshine](https://github.com/LizardByte/Sunshine)
+- **Sao:** 28293
+
+## 2. Mô Tả Dự Án
+LizardByte/Sunshine là một máy chủ phát trực tiếp game mã nguồn mở, tự lưu trữ được thiết kế để hoạt động liền mạch với ứng dụng khách Moonlight. Nó cho phép người dùng phát trực tiếp game từ máy tính chơi game cá nhân của họ đến bất kỳ thiết bị tương thích nào qua mạng nội bộ hoặc internet, cung cấp trải nghiệm phát trực tiếp độ trễ thấp, chất lượng cao mà không phụ thuộc vào dịch vụ đám mây của bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Sunshine là giải pháp thay thế mạnh mẽ cho các dịch vụ phát trực tiếp game độc quyền như:
+- NVIDIA GeForce Experience (GFE) và chức năng GameStream
+- Steam Link (khi được sử dụng để chơi từ xa bên ngoài hệ sinh thái Steam)
+- Parsec (cho các thiết lập tự lưu trữ)
+- Các nền tảng game đám mây thương mại cho các trường hợp sử dụng phát trực tiếp cục bộ
+
+## 4. Chức Năng Chính
+Các tính năng chính của Sunshine bao gồm:
+- **Phát trực tiếp Độ trễ Thấp:** Được tối ưu hóa cho chơi game thời gian thực với độ trễ đầu vào tối thiểu.
+- **Hỗ trợ Đa nền tảng:** Hoạt động trên Windows, Linux và macOS, cả máy chủ và máy khách (qua Moonlight).
+- **Mã hóa Phần cứng:** Tận dụng mã hóa GPU (NVENC, AMF, VAAPI) cho hiệu suất hiệu quả.
+- **Giao diện Web:** Cấu hình dễ dàng thông qua bảng điều khiển dựa trên trình duyệt trực quan.
+- **Xác thực & Bảo mật:** Hỗ trợ xác thực dựa trên mã PIN và người dùng/mật khẩu.
+- **Độ phân giải & Bitrate Tùy chỉnh:** Điều chỉnh chất lượng phát trực tiếp dựa trên điều kiện mạng.
+- **Hỗ trợ Nhiều Màn hình:** Phát trực tiếp các màn hình cụ thể hoặc tất cả các màn hình cùng lúc.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Quyền riêng tư & Kiểm soát:** Bản chất tự lưu trữ đảm bảo dữ liệu ở lại trên phần cứng của bạn.
+- **Tiết kiệm Chi phí:** Miễn phí và mã nguồn mở, tránh phí đăng ký.
+- **Tùy chỉnh:** Có thể cấu hình cao để phù hợp với các thiết lập phần cứng và mạng cụ thể.
+- **Cộng đồng Tích cực:** Sự hiện diện mạnh mẽ trên GitHub với các bản cập nhật và hỗ trợ thường xuyên.
+
+**Nhược điểm:**
+- **Độ phức tạp khi Thiết lập:** Yêu cầu kiến thức kỹ thuật cho cấu hình ban đầu và khắc phục sự cố.
+- **Phụ thuộc vào Phần cứng:** Hiệu suất phụ thuộc vào khả năng của máy chủ và độ ổn định của mạng.
+- **Không có Ứng dụng Di động Chính thức:** Phụ thuộc vào ứng dụng khách bên thứ ba như Moonlight để truy cập di động.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để cài đặt Sunshine trên máy chủ Ubuntu (22.04 LTS trở lên):
+
+### Yêu cầu:
+- Ubuntu Linux (đã thử nghiệm trên 22.04)
+- Quyền sudo
+- GPU được hỗ trợ (NVIDIA, AMD hoặc Intel với VAAPI)
+
+### Bước 1: Cập nhật Hệ thống
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+### Bước 2: Cài đặt Các Gói Phụ thuộc
+```bash
+sudo apt install -y git cmake gcc g++ libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libopus-dev libssl-dev
+```
+
+### Bước 3: Cài đặt Sunshine
+Sao chép kho lưu trữ và biên dịch:
+```bash
+git clone https://github.com/LizardByte/Sunshine.git
+cd Sunshine
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+sudo make install
+```
+
+### Bước 4: Cấu hình Sunshine
+Chỉnh sửa tệp cấu hình (nằm tại `~/.config/sunshine/sunshine.conf`) để thiết lập người dùng, độ phân giải và tùy chọn bitrate.
+
+### Bước 5: Chạy Sunshine
+Khởi động dịch vụ:
+```bash
+sunshine
+```
+Truy cập giao diện web tại `https://localhost:47990` để hoàn tất thiết lập.
+
+### Bước 6 (Tùy chọn): Thiết lập như một Dịch vụ
+Tạo một tệp dịch vụ systemd để tự động khởi động:
+```bash
+sudo nano /etc/systemd/system/sunshine.service
+```
+Thêm:
+```
+[Unit]
+Description=Sunshine Game Streaming
+After=network.target
+
+[Service]
+Type=simple
+User=your_username
+ExecStart=/usr/local/bin/sunshine
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+Sau đó kích hoạt và khởi động:
+```bash
+sudo systemctl enable sunshine
+sudo systemctl start sunshine
+```
+
+Máy chủ Sunshine tự lưu trữ của bạn đã sẵn sàng! Sử dụng Moonlight trên thiết bị khách của bạn để kết nối và bắt đầu phát trực tiếp.

--- a/src/content/posts/Self-host-PostHog-posthog-vi.md
+++ b/src/content/posts/Self-host-PostHog-posthog-vi.md
@@ -1,0 +1,120 @@
+---
+lang: vi
+title: "PostHog: Giải Pháp Thay Thế Mã Nguồn Mở Tối Ưu Cho Phân Tích Sản Phẩm và A/B Testing"
+description: "Khám phá PostHog, nền tảng mã nguồn mở cung cấp phân tích web, ghi lại phiên, cờ tính năng và thử nghiệm A/B mà bạn có thể tự lưu trữ miễn phí."
+published: 2025-09-10
+tags: ['open-source', 'self-host', 'analytics', 'feature-flags', 'session-recording', 'a-b-testing', 'docker', 'python', 'react']
+category: Self-hosted
+author: minhpt
+---
+
+# PostHog/posthog - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/PostHog/posthog](https://github.com/PostHog/posthog)
+- **Sao:** 28566
+
+## 2. Mô Tả Dự Án
+PostHog là một nền tảng mã nguồn mở đa năng, được thiết kế để giúp các doanh nghiệp hiểu hành vi người dùng, tối ưu hóa các tính năng sản phẩm và chạy thử nghiệm mà không phụ thuộc vào dịch vụ bên thứ ba. Nó kết hợp phân tích web và sản phẩm, ghi lại phiên, cờ tính năng và thử nghiệm A/B thành một giải pháp duy nhất, có thể tự lưu trữ. Được xây dựng với công nghệ hiện đại bao gồm Python, Django và React, PostHog trao quyền cho các nhóm duy trì toàn quyền kiểm soát dữ liệu của họ trong khi tận dụng những hiểu biết mạnh mẽ để thúc đẩy tăng trưởng.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+PostHog là giải pháp thay thế toàn diện cho một số công cụ thương mại và mã nguồn mở phổ biến, bao gồm:
+- **Mixpanel** và **Amplitude** cho phân tích sản phẩm.
+- **Hotjar** hoặc **FullStory** cho ghi lại phiên.
+- **LaunchDarkly** hoặc **Split** cho cờ tính năng.
+- **Optimizely** hoặc **Google Optimize** cho thử nghiệm A/B.
+Bằng cách hợp nhất các chức năng này, PostHog giảm sự phân mảnh công cụ và cung cấp một giải pháp hợp nhất, tiết kiệm chi phí cho các nhóm dựa trên dữ liệu.
+
+## 4. Chức Năng Chính
+Bộ tính năng của PostHog rất mạnh mẽ và đa dạng:
+- **Phân tích Sản phẩm:** Theo dõi sự kiện, kênh chuyển đổi, tỷ lệ giữ chân và đường dẫn người dùng để hiểu cách mọi người tương tác với sản phẩm của bạn.
+- **Ghi lại Phiên:** Chụp và phát lại các phiên người dùng để xác định vấn đề UX và cơ hội cải thiện.
+- **Cờ Tính năng:** Triển khai các tính năng mới một cách an toàn với các bản phát hành có mục tiêu và công tắc tắt.
+- **Thử nghiệm A/B:** Chạy các thử nghiệm để kiểm tra giả thuyết và tối ưu hóa tỷ lệ chuyển đổi.
+- **Tự Lưu trữ:** Triển khai trên cơ sở hạ tầng của riêng bạn để đảm bảo quyền riêng tư, bảo mật và tuân thủ dữ liệu.
+- **Tích hợp:** Kết nối với các công cụ như Slack, Salesforce và kho dữ liệu để mở rộng chức năng.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Mã nguồn Mở:** Miễn phí sử dụng, sửa đổi và mở rộng; phát triển minh bạch.
+- **Nền tảng Đa năng:** Giảm sự phụ thuộc vào nhiều công cụ SaaS.
+- **Quyền sở hữu Dữ liệu:** Tự lưu trữ đảm bảo dữ liệu không bao giờ rời khỏi môi trường của bạn.
+- **Cộng đồng Tích cực:** Sự hiện diện mạnh mẽ trên GitHub với các bản cập nhật và đóng góp thường xuyên.
+- **Khả năng Mở rộng:** Xử lý khối lượng sự kiện và người dùng lớn một cách hiệu quả.
+
+**Nhược điểm:**
+- **Độ phức tạp khi Tự lưu trữ:** Yêu cầu chuyên môn kỹ thuật để triển khai và bảo trì.
+- **Tốn nhiều Tài nguyên:** Có thể yêu cầu tài nguyên máy chủ đáng kể cho các triển khai quy mô lớn.
+- **Đường cong Học tập:** Người dùng mới có thể cần thời gian để tận dụng đầy đủ tất cả các tính năng.
+- **Tùy chọn Được Quản lý Hạn chế:** Mặc dù có phiên bản đám mây, nhưng giá trị cốt lõi nằm ở việc tự lưu trữ, điều này không phù hợp với tất cả mọi người.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai PostHog trên máy chủ Ubuntu (20.04 trở lên). Hướng dẫn này giả định bạn có kiến thức cơ bản về lệnh Linux và Docker.
+
+### Yêu cầu:
+- Máy chủ Ubuntu (khuyến nghị: 4GB RAM, 2 vCPU).
+- Docker và Docker Compose đã được cài đặt.
+- Tên miền trỏ đến máy chủ của bạn (cho HTTPS).
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt install docker-ce docker-ce-cli containerd.io -y
+sudo systemctl enable docker && sudo systemctl start docker
+```
+
+### Bước 2: Cài đặt Docker Compose
+```bash
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+### Bước 3: Sao chép PostHog và Cấu hình
+```bash
+git clone https://github.com/PostHog/posthog.git
+cd posthog
+cp .env.template .env
+```
+Chỉnh sửa `.env` để thiết lập:
+- `SECRET_KEY`: Tạo khóa bảo mật (ví dụ: sử dụng `openssl rand -hex 32`).
+- `SITE_URL`: Tên miền của bạn (ví dụ: `https://posthog.yourdomain.com`).
+
+### Bước 4: Khởi động PostHog với Docker Compose
+```bash
+docker-compose up -d
+```
+Thao tác này sẽ kéo các image và khởi động các dịch vụ bao gồm PostgreSQL, Redis và ứng dụng PostHog.
+
+### Bước 5: Thiết lập Reverse Proxy (Nginx) và SSL
+Cài đặt Nginx và Certbot:
+```bash
+sudo apt install nginx certbot python3-certbot-nginx -y
+```
+Tạo tệp cấu hình Nginx tại `/etc/nginx/sites-available/posthog`:
+```nginx
+server {
+    listen 80;
+    server_name posthog.yourdomain.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+Kích hoạt site và lấy chứng chỉ SSL:
+```bash
+sudo ln -s /etc/nginx/sites-available/posthog /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d posthog.yourdomain.com
+```
+
+### Bước 6: Truy cập PostHog
+Điều hướng đến `https://posthog.yourdomain.com` trong trình duyệt của bạn. Hoàn tất trình hướng dẫn thiết lập để tạo tài khoản quản trị và bắt đầu sử dụng PostHog.
+
+Để biết thêm tùy chỉnh, hãy tham khảo [tài liệu chính thức](https://posthog.com/docs/self-host).

--- a/src/content/posts/Self-host-TabbyML-tabby-vi.md
+++ b/src/content/posts/Self-host-TabbyML-tabby-vi.md
@@ -1,0 +1,129 @@
+---
+lang: vi
+title: "TabbyML/tabby: Hướng Dẫn Toàn Diện Về Trợ Lý Lập Trình AI Tự Lưu Trữ"
+description: "Khám phá TabbyML/tabby, trợ lý lập trình AI mã nguồn mở, tự lưu trữ với 31.998 sao GitHub. Tìm hiểu cách triển khai và sử dụng như một giải pháp thay thế cho các công cụ thương mại."
+published: 2025-09-06
+tags: ['open-source', 'self-host', 'AI', 'coding-assistant', 'Docker', 'machine-learning']
+category: Self-hosted
+author: minhpt
+---
+
+# TabbyML/tabby - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/TabbyML/tabby](https://github.com/TabbyML/tabby)
+- **Sao:** 31998
+
+## 2. Mô Tả Dự Án
+
+TabbyML/tabby là một trợ lý lập trình AI mã nguồn mở, tự lưu trữ được thiết kế để cung cấp tính năng tự động hoàn thành mã, gợi ý và hỗ trợ theo ngữ cảnh trực tiếp trong môi trường phát triển của bạn. Nó tận dụng các mô hình học máy để hiểu các mẫu mã và cung cấp hỗ trợ thời gian thực, khiến nó trở thành một công cụ mạnh mẽ cho các nhà phát triển muốn nâng cao năng suất mà không phụ thuộc vào các dịch vụ đám mây.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+TabbyML/tabby là giải pháp thay thế hấp dẫn cho một số trợ lý lập trình AI thương mại và độc quyền, bao gồm:
+
+- GitHub Copilot
+- Tabnine (phiên bản Pro/Enterprise)
+- Amazon CodeWhisperer
+- JetBrains AI Assistant
+
+Bằng cách cung cấp giải pháp tự lưu trữ, nó mang lại khả năng kiểm soát tốt hơn đối với quyền riêng tư dữ liệu, tùy chỉnh và quản lý chi phí so với các dịch vụ đăng ký này.
+
+## 4. Chức Năng Chính
+
+Các tính năng chính của TabbyML/tabby bao gồm:
+
+- **Hoàn thành Mã:** Gợi ý nhạy ngữ cảnh cho các đoạn mã, hàm và biến.
+- **Hỗ trợ Đa Ngôn ngữ:** Tương thích với các ngôn ngữ lập trình phổ biến như Python, JavaScript, TypeScript, Java và hơn thế nữa.
+- **Huấn luyện Mô hình Tùy chỉnh:** Khả năng tinh chỉnh mô hình trên cơ sở mã của bạn để được hỗ trợ cá nhân hóa.
+- **Tích hợp IDE:** Hoạt động với các trình soạn thảo mã chính như VS Code, IntelliJ và các trình khác thông qua tiện ích mở rộng.
+- **Quyền riêng tư Trước hết:** Tất cả quá trình xử lý diễn ra trên cơ sở hạ tầng của bạn, đảm bảo mã không bao giờ rời khỏi môi trường của bạn.
+- **Kiến trúc Mở rộng:** Hỗ trợ plugin và cấu hình tùy chỉnh cho quy trình làm việc phù hợp.
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- **Quyền riêng tư Dữ liệu:** Bản chất tự lưu trữ đảm bảo kiểm soát hoàn toàn mã và dữ liệu của bạn.
+- **Tiết kiệm Chi phí:** Không có phí đăng ký định kỳ; chi phí thiết lập một lần.
+- **Tùy chỉnh:** Tinh chỉnh mô hình để phù hợp với cơ sở mã và phong cách lập trình của bạn.
+- **Mã nguồn Mở:** Cải tiến do cộng đồng thúc đẩy và minh bạch.
+- **Khả năng Ngoại tuyến:** Hoạt động mà không cần kết nối internet sau khi đã triển khai.
+
+**Nhược điểm:**
+- **Độ phức tạp Thiết lập Ban đầu:** Yêu cầu kiến thức kỹ thuật để triển khai và bảo trì.
+- **Tốn nhiều Tài nguyên:** Có thể yêu cầu tài nguyên tính toán đáng kể cho suy luận và huấn luyện mô hình.
+- **Hiệu suất Tiêu chuẩn Hạn chế:** Có thể cần tinh chỉnh tùy chỉnh để đạt kết quả tối ưu so với các đối thủ đám mây.
+- **Hỗ trợ Cộng đồng:** Mặc dù đang phát triển, nhưng có thể không sánh bằng hỗ trợ tức thời của các lựa chọn thương mại.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Thực hiện theo các bước sau để triển khai TabbyML/tabby trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Ubuntu 20.04 trở lên
+- Docker và Docker Compose đã được cài đặt
+- Ít nhất 8GB RAM (khuyến nghị 16GB cho hiệu suất tốt hơn)
+- Đủ dung lượng lưu trữ cho các tệp mô hình (thay đổi tùy theo kích thước mô hình)
+
+### Cài đặt Từng bước:
+
+1. **Cập nhật Gói Hệ thống:**
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   ```
+
+2. **Cài đặt Docker và Docker Compose:**
+   ```bash
+   sudo apt install docker.io docker-compose -y
+   sudo systemctl enable docker
+   sudo systemctl start docker
+   ```
+
+3. **Tạo Thư mục cho Tabby:**
+   ```bash
+   mkdir tabby && cd tabby
+   ```
+
+4. **Tạo Tệp Docker Compose:**
+   Tạo một tệp `docker-compose.yml` với nội dung sau:
+   ```yaml
+   version: '3.8'
+
+   services:
+     tabby:
+       image: tabbyml/tabby:latest
+       container_name: tabby
+       ports:
+         - "8080:8080"
+       volumes:
+         - ./data:/data
+       environment:
+         - TABBY_HOST=0.0.0.0
+       restart: unless-stopped
+   ```
+
+5. **Triển khai Tabby:**
+   ```bash
+   sudo docker-compose up -d
+   ```
+
+6. **Xác minh Cài đặt:**
+   Kiểm tra xem container có đang chạy không:
+   ```bash
+   sudo docker ps
+   ```
+   Truy cập dịch vụ tại `http://your-server-ip:8080` trong trình duyệt của bạn.
+
+7. **Cấu hình IDE của Bạn:**
+   Cài đặt tiện ích mở rộng Tabby trong trình soạn thảo mã ưa thích của bạn (ví dụ: VS Code) và trỏ nó đến IP và cổng của máy chủ.
+
+8. **Tải Mô hình (Tùy chọn):**
+   Tabby sẽ tải các mô hình mặc định khi chạy lần đầu. Đối với mô hình tùy chỉnh, hãy tham khảo [tài liệu chính thức](https://github.com/TabbyML/tabby).
+
+### Mẹo Khắc phục Sự cố:
+- Đảm bảo cổng 8080 được mở trong tường lửa của bạn.
+- Kiểm tra nhật ký Docker để tìm lỗi: `sudo docker logs tabby`
+- Phân bổ thêm tài nguyên nếu gặp vấn đề về hiệu suất.
+
+Đối với các cấu hình nâng cao và tinh chỉnh mô hình, hãy truy cập [kho lưu trữ GitHub TabbyML/tabby](https://github.com/TabbyML/tabby).

--- a/src/content/posts/Self-host-airbytehq-airbyte-vi.md
+++ b/src/content/posts/Self-host-airbytehq-airbyte-vi.md
@@ -1,0 +1,151 @@
+---
+lang: vi
+title: "Airbyte: Nền Tảng Tích Hợp Dữ Liệu Mã Nguồn Mở Tối Ưu Cho ETL/ELT"
+description: "Đánh giá toàn diện về Airbyte - nền tảng tích hợp dữ liệu mã nguồn mở hàng đầu để xây dựng đường ống ETL/ELT từ API, cơ sở dữ liệu và tệp đến kho dữ liệu và hồ dữ liệu."
+published: 2025-09-18
+tags: ['open-source', 'self-host', 'data-integration', 'etl', 'elt', 'docker', 'data-pipelines']
+category: Self-hosted
+author: minhpt
+---
+
+# airbytehq/airbyte - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/airbytehq/airbyte](https://github.com/airbytehq/airbyte)
+- **Sao:** 19271
+
+## 2. Mô Tả Dự Án
+
+Airbyte là một nền tảng tích hợp dữ liệu mã nguồn mở mạnh mẽ cho phép các tổ chức xây dựng các đường ống dữ liệu ETL/ELT mạnh mẽ. Nó kết nối với nhiều nguồn dữ liệu khác nhau bao gồm API, cơ sở dữ liệu và tệp, và tải dữ liệu vào kho dữ liệu, hồ dữ liệu và nhà hồ dữ liệu. Nền tảng này cung cấp cả tùy chọn triển khai tự lưu trữ và lưu trữ đám mây, giúp nó linh hoạt cho các nhu cầu tổ chức khác nhau.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Airbyte là giải pháp thay thế hấp dẫn cho một số giải pháp tích hợp dữ liệu thương mại và mã nguồn mở, bao gồm:
+
+- **Fivetran**: Nền tảng ELT thương mại
+- **Stitch Data**: Dịch vụ ETL đám mây (đã được Talend mua lại)
+- **Matillion**: Nền tảng biến đổi và tích hợp dữ liệu
+- **Talend**: Bộ tích hợp dữ liệu doanh nghiệp
+- **Apache Nifi**: Công cụ định tuyến và biến đổi dữ liệu mã nguồn mở
+- **Singer**: Khung ETL mã nguồn mở
+
+## 4. Chức Năng Chính
+
+Các tính năng chính của Airbyte bao gồm:
+
+- **300+ Bộ Kết nối**: Thư viện phong phú các bộ kết nối được xây dựng sẵn cho nhiều nguồn và đích dữ liệu khác nhau
+- **Phát triển Bộ Kết nối Tùy chỉnh**: SDK để xây dựng bộ kết nối tùy chỉnh bằng bất kỳ ngôn ngữ nào
+- **Hỗ trợ CDC**: Change Data Capture để đồng bộ hóa dữ liệu hiệu quả
+- **Điều phối**: Khả năng lập lịch và giám sát tích hợp sẵn
+- **Chuẩn hóa Dữ liệu**: Quản lý lược đồ tự động và xử lý kiểu dữ liệu
+- **Truy cập API & Giao diện**: Cả giao diện đồ họa và API để quản lý đường ống
+- **Khả năng Mở rộng**: Kiến trúc mô-đun cho phép mở rộng và sửa đổi tùy chỉnh
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Mã nguồn mở và miễn phí sử dụng
+- Hệ sinh thái bộ kết nối phong phú
+- Hỗ trợ cộng đồng mạnh mẽ và phát triển tích cực
+- Tùy chọn triển khai linh hoạt (tự lưu trữ hoặc đám mây)
+- Tài liệu tốt và cơ sở người dùng đang phát triển
+- Hỗ trợ cả hai mô hình ETL và ELT
+
+**Nhược điểm:**
+- Triển khai tự lưu trữ yêu cầu chuyên môn kỹ thuật
+- Một số tính năng doanh nghiệp có thể yêu cầu hỗ trợ thương mại
+- Đường cong học tập cho các kịch bản biến đổi dữ liệu phức tạp
+- Tốn nhiều tài nguyên cho các triển khai quy mô lớn
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+
+- Docker Engine 20.10+
+- Docker Compose 1.29+
+- Tối thiểu 4GB RAM, 2 lõi CPU
+- 20GB+ dung lượng đĩa trống
+
+### Cài đặt Từng bước
+
+1. **Cập nhật Gói Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+2. **Cài đặt Docker**
+```bash
+sudo apt install docker.io -y
+sudo systemctl enable --now docker
+```
+
+3. **Cài đặt Docker Compose**
+```bash
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+4. **Tạo Thư mục Airbyte**
+```bash
+mkdir airbyte && cd airbyte
+```
+
+5. **Tải Tệp Docker Compose**
+```bash
+curl -sO https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,docker-compose.yaml}
+```
+
+6. **Khởi động Dịch vụ Airbyte**
+```bash
+docker-compose up -d
+```
+
+7. **Xác minh Cài đặt**
+```bash
+docker-compose ps
+```
+
+8. **Truy cập Giao diện Web Airbyte**
+Mở trình duyệt và điều hướng đến `http://your-server-ip:8000`
+
+### Cấu hình Sau Cài đặt
+
+1. **Thiết lập Tài khoản Quản trị Ban đầu**
+   - Thông tin đăng nhập mặc định: airbyte/password
+   - Thay đổi mật khẩu ngay sau lần đăng nhập đầu tiên
+
+2. **Cấu hình Lưu trữ**
+   - Thiết lập các ổ đĩa liên tục để lưu trữ dữ liệu
+   - Cấu hình chiến lược sao lưu cho dữ liệu quan trọng
+
+3. **Cấu hình Mạng**
+   - Đảm bảo các quy tắc tường lửa phù hợp cho các cổng cần thiết
+   - Thiết lập SSL/TLS để truy cập an toàn
+
+### Lệnh Bảo trì
+
+```bash
+# Kiểm tra trạng thái dịch vụ
+docker-compose ps
+
+# Xem nhật ký
+docker-compose logs -f
+
+# Khởi động lại dịch vụ
+docker-compose restart
+
+# Cập nhật lên phiên bản mới nhất
+docker-compose down
+git pull origin master
+docker-compose up -d
+```
+
+### Mẹo Khắc phục Sự cố
+
+- Đảm bảo các cổng 8000 (giao diện web) và 8001 (API) có thể truy cập được
+- Kiểm tra phân bổ tài nguyên Docker nếu gặp vấn đề về hiệu suất
+- Theo dõi dung lượng đĩa cho khối lượng dữ liệu ngày càng tăng
+- Xem xét nhật ký để tìm các vấn đề cụ thể về bộ kết nối
+
+Quá trình cài đặt này cung cấp một phiên bản Airbyte sẵn sàng cho sản xuất có thể mở rộng theo nhu cầu tích hợp dữ liệu của bạn trong khi vẫn duy trì toàn quyền kiểm soát cơ sở hạ tầng dữ liệu của bạn.

--- a/src/content/posts/Self-host-anderspitman-awesome-tunneling-vi.md
+++ b/src/content/posts/Self-host-anderspitman-awesome-tunneling-vi.md
@@ -1,0 +1,133 @@
+---
+lang: vi
+title: "Anderspitman/awesome-tunneling: Tài Nguyên Đường Hầm Tự Lưu Trữ Tối Ưu"
+description: "Khám phá anderspitman/awesome-tunneling, danh sách tuyển chọn các giải pháp thay thế ngrok và Cloudflare Tunnel cho các giải pháp đường hầm an toàn, tự lưu trữ."
+published: 2025-09-20
+tags: ['open-source', 'self-host', 'tunneling', 'networking', 'devops']
+category: Self-hosted
+author: minhpt
+---
+
+# anderspitman/awesome-tunneling - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/anderspitman/awesome-tunneling](https://github.com/anderspitman/awesome-tunneling)
+- **Sao:** 18613
+
+## 2. Mô Tả Dự Án
+Anderspitman/awesome-tunneling là một danh sách được tuyển chọn tỉ mỉ về các phần mềm và dịch vụ đường hầm, tập trung vào các giải pháp thay thế tự lưu trữ cho các giải pháp thương mại phổ biến như ngrok và Cloudflare Tunnel. Nó phục vụ như một tài nguyên toàn diện cho các nhà phát triển, quản trị viên hệ thống và chuyên gia DevOps đang tìm kiếm thiết lập các đường hầm mạng riêng tư, an toàn mà không phụ thuộc vào dịch vụ bên thứ ba. Kho lưu trữ phân loại các công cụ dựa trên tính năng, giao thức và mức độ dễ sử dụng, khiến nó trở thành tài liệu tham khảo vô giá cho bất kỳ ai tham gia vào mạng, truy cập từ xa hoặc hiển thị dịch vụ.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Dự án này cung cấp các giải pháp thay thế cho một số dịch vụ đường hầm và reverse proxy được sử dụng rộng rãi, bao gồm:
+- **ngrok**
+- **Cloudflare Tunnel**
+- **PageKite**
+- **LocalTunnel**
+- **Serveo**
+- **Teleconsole**
+- **Beeceptor** (cho giả lập HTTP)
+- Nhiều giải pháp đường hầm độc quyền hoặc SaaS khác.
+
+## 4. Chức Năng Chính
+Bản thân kho lưu trữ awesome-tunneling không phải là một ứng dụng phần mềm mà là một danh sách phân loại các công cụ. Các tính năng chính của phần mềm được liệt kê thường bao gồm:
+- Đường hầm TCP/UDP/HTTP an toàn.
+- Hỗ trợ tự lưu trữ để duy trì quyền riêng tư dữ liệu.
+- Khả năng reverse proxy.
+- Kết thúc SSL/TLS.
+- DNS động và quản lý tên miền phụ.
+- Tương thích đa nền tảng (Linux, Windows, macOS).
+- Tích hợp với Docker, Kubernetes và các công cụ điều phối khác.
+- Cơ chế xác thực và kiểm soát truy cập.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Danh sách công cụ toàn diện và được tổ chức tốt.
+- Tập trung vào các giải pháp mã nguồn mở và tự lưu trữ giúp tăng cường quyền riêng tư và kiểm soát.
+- Được cập nhật thường xuyên với các dự án mới và cải tiến.
+- Bao gồm so sánh, giúp dễ dàng chọn công cụ phù hợp.
+- Được cộng đồng thúc đẩy, với sự đóng góp từ các chuyên gia trong lĩnh vực.
+
+**Nhược điểm:**
+- Là một danh sách chứ không phải một công cụ duy nhất, người dùng phải đánh giá và triển khai từng giải pháp riêng lẻ.
+- Một số dự án được liệt kê có thể có đường cong học tập dốc hoặc tài liệu hạn chế.
+- Yêu cầu tự bảo trì phần mềm đường hầm đã chọn, bao gồm cập nhật và bản vá bảo mật.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Vì anderspitman/awesome-tunneling là một danh sách các công cụ, đây là hướng dẫn chung để tự lưu trữ một phần mềm đường hầm phổ biến từ danh sách, chẳng hạn như **frp** (Fast Reverse Proxy), trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Máy chủ Ubuntu 22.04 LTS.
+- Quyền sudo.
+- Kiến thức cơ bản về dòng lệnh Linux.
+
+### Bước 1: Cập nhật Hệ thống
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+### Bước 2: Tải frp
+Truy cập [trang phát hành frp trên GitHub](https://github.com/fatedier/frp/releases) để tìm phiên bản mới nhất. Ví dụ, để tải v0.52.3 cho AMD64:
+```bash
+wget https://github.com/fatedier/frp/releases/download/v0.52.3/frp_0.52.3_linux_amd64.tar.gz
+tar -xzf frp_0.52.3_linux_amd64.tar.gz
+cd frp_0.52.3_linux_amd64
+```
+
+### Bước 3: Cấu hình Máy chủ frp
+Chỉnh sửa tệp cấu hình máy chủ (`frps.ini`):
+```bash
+nano frps.ini
+```
+Ví dụ cấu hình:
+```ini
+[common]
+bind_port = 7000
+dashboard_port = 7500
+dashboard_user = admin
+dashboard_pwd = your_secure_password
+token = your_secret_token
+```
+
+### Bước 4: Chạy Máy chủ frp
+Khởi động máy chủ frp:
+```bash
+./frps -c frps.ini
+```
+Để chạy như một dịch vụ, tạo một tệp dịch vụ systemd:
+```bash
+sudo nano /etc/systemd/system/frps.service
+```
+Thêm:
+```ini
+[Unit]
+Description=Frp Server Service
+After=network.target
+
+[Service]
+Type=simple
+User=nobody
+Restart=on-failure
+RestartSec=5s
+ExecStart=/path/to/frps -c /path/to/frps.ini
+
+[Install]
+WantedBy=multi-user.target
+```
+Sau đó kích hoạt và khởi động dịch vụ:
+```bash
+sudo systemctl enable frps
+sudo systemctl start frps
+```
+
+### Bước 5: Cấu hình Tường lửa
+Cho phép các cổng cần thiết (ví dụ: 7000, 7500):
+```bash
+sudo ufw allow 7000/tcp
+sudo ufw allow 7500/tcp
+sudo ufw reload
+```
+
+### Bước 6: Truy cập Bảng Điều khiển
+Mở trình duyệt và điều hướng đến `http://your_server_ip:7500`, sử dụng thông tin đăng nhập đã đặt trong `frps.ini`.
+
+Thiết lập này cung cấp một giải pháp đường hầm tự lưu trữ tương tự như ngrok, cho phép bạn hiển thị các dịch vụ cục bộ một cách an toàn. Đối với các công cụ khác được liệt kê trong awesome-tunneling, hãy tham khảo tài liệu tương ứng của chúng để biết hướng dẫn cài đặt và cấu hình.

--- a/src/content/posts/Self-host-awesome-selfhosted-awesome-selfhosted-vi.md
+++ b/src/content/posts/Self-host-awesome-selfhosted-awesome-selfhosted-vi.md
@@ -1,0 +1,148 @@
+---
+lang: vi
+title: "Awesome Self-Hosted: Hướng Dẫn Tài Nguyên Tự Lưu Trữ Mã Nguồn Mở Tối Ưu"
+description: "Khám phá awesome-selfhosted/awesome-selfhosted - kho lưu trữ GitHub toàn diện với hơn 243k sao, bao gồm phần mềm miễn phí cho các giải pháp thay thế tự lưu trữ cho các dịch vụ phổ biến."
+published: 2025-08-24
+tags: ['open-source', 'self-host', 'github', 'free-software', 'server', 'privacy', 'docker', 'devops']
+category: Self-hosted
+author: minhpt
+---
+
+# awesome-selfhosted/awesome-selfhosted - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/awesome-selfhosted/awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted)
+- **Sao:** 243297
+- **Giấy phép:** Nhiều loại (Danh sách tuyển chọn)
+- **Cập nhật Lần cuối:** Tháng 8, 2025
+
+## 2. Mô Tả Dự Án
+
+Awesome Self-Hosted không phải là một ứng dụng phần mềm đơn lẻ mà là một kho lưu trữ GitHub được tuyển chọn tỉ mỉ, phục vụ như thư mục xác định cho phần mềm miễn phí và mã nguồn mở có thể được tự lưu trữ trên máy chủ cá nhân. Bộ sưu tập toàn diện này trải dài trên nhiều danh mục bao gồm công cụ giao tiếp, máy chủ phương tiện, chia sẻ tệp, bộ ứng dụng năng suất và công cụ phát triển. Với hơn 243.000 sao, nó đại diện cho tài nguyên lớn nhất được cộng đồng xác nhận để khám phá các lựa chọn thay thế có thể tự lưu trữ cho các sản phẩm SaaS thương mại.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Kho lưu trữ cung cấp các giải pháp thay thế cho nhiều dịch vụ thương mại phổ biến bao gồm:
+
+- **Google Drive/Dropbox:** Nextcloud, ownCloud, Seafile
+- **Spotify/Apple Music:** Funkwhale, Airsonic, Navidrome
+- **Slack/Discord:** Mattermost, Rocket.Chat, Matrix
+- **Trello/Asana:** Wekan, Taiga, Focalboard
+- **Netflix/Plex:** Jellyfin, Emby, Plex (giải pháp thay thế mã nguồn mở)
+- **Google Docs/Office 365:** OnlyOffice, Collabora Online, Etherpad
+- **Twitter/Facebook:** Mastodon, Pleroma, Friendica
+- **GitHub/GitLab:** Gitea, Forgejo, GitLab CE
+
+## 4. Chức Năng Chính
+
+Kho lưu trữ hoạt động như một chỉ mục được phân loại với:
+
+- **Danh sách Phân loại:** Được tổ chức thành hơn 40 danh mục từ "Nền tảng Blog" đến "Wiki"
+- **Lọc Chất lượng:** Chỉ bao gồm phần mềm được bảo trì tích cực và thực sự có thể tự lưu trữ
+- **Thông tin Giấy phép:** Ghi nhãn rõ ràng về giấy phép phần mềm (AGPL, MIT, GPL, v.v.)
+- **Chi tiết Công nghệ:** Bao gồm thông tin về các công nghệ yêu cầu (Python, Node.js, Docker, v.v.)
+- **Đánh giá Cộng đồng:** Chỉ số chất lượng ngầm thông qua sao GitHub và hoạt động
+- **Cập nhật Thường xuyên:** Được duy trì bởi sự đóng góp của cộng đồng và đánh giá định kỳ
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- 🟢 Bộ sưu tập khổng lồ bao phủ hầu hết mọi nhu cầu tự lưu trữ
+- 🟢 Đảm bảo chất lượng được cộng đồng xác nhận
+- 🟢 Cập nhật thường xuyên và bổ sung mới
+- 🟢 Thông tin giấy phép rõ ràng cho mỗi dự án
+- 🟢 Phân loại và khả năng tìm kiếm tuyệt vời
+- 🟢 Hoàn toàn miễn phí và mã nguồn mở
+
+**Nhược điểm:**
+- 🔴 Có thể gây choáng ngợp cho người mới bắt đầu do số lượng lớn
+- 🔴 Không có công cụ cài đặt tích hợp (chỉ là một thư mục)
+- 🔴 Chất lượng khác nhau giữa các dự án được liệt kê
+- 🔴 Yêu cầu kiến thức kỹ thuật để triển khai giải pháp
+- 🔴 Không có hỗ trợ hoặc tài liệu tập trung
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Vì awesome-selfhosted là một thư mục chứ không phải một ứng dụng đơn lẻ, đây là cách thiết lập một ứng dụng tự lưu trữ điển hình từ danh sách bằng Docker (sử dụng Nextcloud làm ví dụ):
+
+### Yêu cầu
+- Máy chủ Ubuntu 22.04 LTS
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến máy chủ của bạn (tùy chọn nhưng khuyến nghị)
+
+### Bước 1: Cài đặt Docker
+```bash
+# Cập nhật hệ thống
+sudo apt update && sudo apt upgrade -y
+
+# Cài đặt Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Cài đặt Docker Compose
+sudo apt install docker-compose-plugin -y
+
+# Thêm người dùng vào nhóm docker
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+### Bước 2: Tạo Tệp Docker Compose cho Nextcloud
+```bash
+mkdir nextcloud && cd nextcloud
+nano docker-compose.yml
+```
+
+Dán cấu hình sau:
+```yaml
+version: '3'
+
+services:
+  nextcloud:
+    image: nextcloud:latest
+    restart: always
+    ports:
+      - 8080:80
+    volumes:
+      - nextcloud_data:/var/www/html
+    environment:
+      - MYSQL_HOST=db
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_PASSWORD=your_secure_password
+
+  db:
+    image: mariadb:10.6
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=root_secure_password
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      - MYSQL_PASSWORD=your_secure_password
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  nextcloud_data:
+  db_data:
+```
+
+### Bước 3: Triển khai Nextcloud
+```bash
+# Khởi động các container
+docker compose up -d
+
+# Kiểm tra trạng thái
+docker compose ps
+```
+
+### Bước 4: Truy cập và Cấu hình
+Mở trình duyệt và điều hướng đến `http://your-server-ip:8080`. Hoàn tất trình hướng dẫn thiết lập bằng cách tạo tài khoản quản trị và cấu hình kết nối cơ sở dữ liệu của bạn.
+
+### Các Cân nhắc Bổ sung
+- **Reverse Proxy:** Thiết lập Nginx hoặc Traefik cho SSL và định tuyến tên miền
+- **Sao lưu:** Thực hiện sao lưu thường xuyên các ổ đĩa Docker của bạn
+- **Cập nhật:** Thường xuyên cập nhật container của bạn với `docker compose pull && docker compose up -d`
+
+Đối với các ứng dụng khác được liệt kê trong awesome-selfhosted, hãy kiểm tra tài liệu của từng dự án để biết các yêu cầu cài đặt cụ thể, vì chúng có thể yêu cầu các công nghệ khác nhau như Node.js, Python hoặc hệ thống cơ sở dữ liệu cụ thể.

--- a/src/content/posts/Self-host-chaitin-SafeLine-vi.md
+++ b/src/content/posts/Self-host-chaitin-SafeLine-vi.md
@@ -1,0 +1,86 @@
+---
+lang: vi
+title: "chaitin/SafeLine: Hướng Dẫn Toàn Diện Về Tường Lửa Ứng Dụng Web Tự Lưu Trữ"
+description: "Khám phá chaitin/SafeLine, WAF mã nguồn mở tự lưu trữ bảo vệ các ứng dụng web khỏi các cuộc tấn công. Tìm hiểu về các tính năng, cách cài đặt và các lựa chọn thay thế."
+published: 2025-09-22
+tags: ['open-source', 'self-host', 'waf', 'reverse-proxy', 'security', 'docker', 'nginx']
+category: Self-hosted
+author: minhpt
+---
+
+# chaitin/SafeLine - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/chaitin/SafeLine](https://github.com/chaitin/SafeLine)
+- **Sao:** 17515
+
+## 2. Mô Tả Dự Án
+SafeLine là một giải pháp Tường lửa Ứng dụng Web (WAF) và reverse proxy mạnh mẽ, tự lưu trữ được thiết kế để bảo vệ các ứng dụng web khỏi nhiều mối đe dọa và khai thác mạng. Được phát triển bởi Chaitin, công cụ mã nguồn mở này cung cấp bảo vệ thời gian thực chống lại các lỗ hổng phổ biến như SQL injection, cross-site scripting (XSS) và các rủi ro OWASP Top 10 khác. Nó được xây dựng để linh hoạt, cho phép triển khai trong nhiều môi trường khác nhau mà không phụ thuộc vào dịch vụ bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+SafeLine là giải pháp thay thế cạnh tranh cho cả giải pháp WAF thương mại và mã nguồn mở, bao gồm:
+- WAF thương mại: Imperva, Cloudflare WAF, F5 Advanced WAF
+- Giải pháp thay thế mã nguồn mở: ModSecurity, NAXSI, Coraza WAF
+
+## 4. Chức Năng Chính
+Các tính năng chính của SafeLine bao gồm:
+- Phát hiện và chặn mối đe dọa thời gian thực
+- Khả năng reverse proxy để cân bằng tải và kết thúc SSL
+- Bộ quy tắc tùy chỉnh cho các chính sách bảo mật phù hợp
+- Nhật ký và phân tích chi tiết để phân tích tấn công
+- Hỗ trợ triển khai dựa trên Docker để dễ dàng mở rộng
+- Tích hợp với các máy chủ web hiện có như Nginx
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Mã nguồn mở và miễn phí sử dụng, giảm chi phí vận hành.
+- Tự lưu trữ, đảm bảo quyền riêng tư dữ liệu và kiểm soát hoàn toàn các cấu hình bảo mật.
+- Nhẹ và hiệu quả, với chi phí hiệu suất tối thiểu.
+- Cộng đồng tích cực và cập nhật thường xuyên.
+
+**Nhược điểm:**
+- Yêu cầu chuyên môn kỹ thuật để thiết lập và bảo trì.
+- Hỗ trợ chính thức hạn chế so với các giải pháp doanh nghiệp thương mại.
+- Có thể cần tùy chỉnh cho các trường hợp sử dụng phức tạp.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai SafeLine trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Ubuntu 20.04 trở lên
+- Docker và Docker Compose đã được cài đặt
+- Có kiến thức cơ bản về lệnh terminal
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker && sudo systemctl start docker
+```
+
+### Bước 2: Sao chép Kho lưu trữ SafeLine
+```bash
+git clone https://github.com/chaitin/SafeLine.git
+cd SafeLine
+```
+
+### Bước 3: Cấu hình Môi trường
+Chỉnh sửa tệp `docker-compose.yml` để điều chỉnh các cài đặt như cổng hoặc ổ đĩa nếu cần. Cấu hình mặc định sẽ hoạt động cho hầu hết các thiết lập.
+
+### Bước 4: Khởi động SafeLine với Docker Compose
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 5: Xác minh Cài đặt
+Kiểm tra xem các container có đang chạy không:
+```bash
+sudo docker ps
+```
+Truy cập bảng điều khiển SafeLine qua `http://your-server-ip:8000` (cổng mặc định). Làm theo trình hướng dẫn thiết lập để cấu hình các quy tắc và chính sách WAF của bạn.
+
+### Lưu ý Bổ sung:
+- Đảm bảo các cổng 80 và 443 được mở nếu proxy lưu lượng web.
+- Tham khảo [tài liệu SafeLine](https://github.com/chaitin/SafeLine) chính thức để biết cấu hình nâng cao và khắc phục sự cố.
+
+Bằng cách làm theo các bước này, bạn có thể có một WAF tự lưu trữ đầy đủ chức năng hoạt động chỉ trong vài phút. SafeLine cung cấp một giải pháp mạnh mẽ, tiết kiệm chi phí để tăng cường bảo mật ứng dụng web của bạn.

--- a/src/content/posts/Self-host-cloudreve-cloudreve-vi.md
+++ b/src/content/posts/Self-host-cloudreve-cloudreve-vi.md
@@ -1,0 +1,107 @@
+---
+lang: vi
+title: "Cloudreve: Hệ Thống Quản Lý và Chia Sẻ Tệp Tự Lưu Trữ Tối Ưu"
+description: "Khám phá Cloudreve, giải pháp quản lý tệp mã nguồn mở tự lưu trữ với hỗ trợ đa lưu trữ, cung cấp giải pháp thay thế liền mạch cho các dịch vụ đám mây thương mại."
+published: 2025-09-15
+tags: ['open-source', 'self-host', 'file-management', 'cloud-storage', 'docker', 'golang']
+category: Self-hosted
+author: minhpt
+---
+
+# cloudreve/cloudreve - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/cloudreve/cloudreve](https://github.com/cloudreve/cloudreve)
+- **Sao:** 24686
+
+## 2. Mô Tả Dự Án
+Cloudreve là một hệ thống quản lý và chia sẻ tệp mạnh mẽ, mã nguồn mở, tự lưu trữ được thiết kế để mang lại cho người dùng toàn quyền kiểm soát dữ liệu của họ. Nó hỗ trợ tích hợp với nhiều nhà cung cấp lưu trữ, cho phép quản lý liền mạch các tệp trên nhiều giải pháp lưu trữ đám mây và cục bộ khác nhau. Được xây dựng với hiệu suất và tính linh hoạt trong tâm trí, Cloudreve là giải pháp thay thế mạnh mẽ cho các dịch vụ lưu trữ đám mây độc quyền, cung cấp các tính năng như quản lý người dùng, xem trước tệp và khả năng chia sẻ—tất cả trong khi giữ dữ liệu trên cơ sở hạ tầng bạn kiểm soát.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Cloudreve có thể thay thế hiệu quả một số giải pháp thương mại và mã nguồn mở, bao gồm:
+- Dropbox, Google Drive và OneDrive cho lưu trữ và chia sẻ tệp tự lưu trữ.
+- Nextcloud và ownCloud cho người dùng tìm kiếm giải pháp thay thế nhẹ, dựa trên Golang.
+- Seafile cho những người ưu tiên hỗ trợ đa backend lưu trữ.
+- Các nền tảng đồng bộ và chia sẻ tệp doanh nghiệp (EFSS) thương mại bằng cách cung cấp giải pháp thay thế có thể tùy chỉnh, miễn phí.
+
+## 4. Chức Năng Chính
+Cloudreve cung cấp một bộ tính năng toàn diện, như:
+- **Hỗ trợ Đa Lưu trữ:** Kết nối với lưu trữ cục bộ, AWS S3, Aliyun OSS, OneDrive và hơn thế nữa.
+- **Quản lý Người dùng và Nhóm:** Tạo người dùng, đặt hạn ngạch lưu trữ và quản lý quyền.
+- **Chia sẻ Tệp:** Tạo liên kết chia sẻ có ngày hết hạn và bảo vệ bằng mật khẩu.
+- **Xem trước Tệp:** Hỗ trợ xem trước tài liệu, hình ảnh, âm thanh và tệp video.
+- **Hỗ trợ WebDAV:** Truy cập và quản lý tệp qua ứng dụng khách WebDAV.
+- **Chủ đề và Tùy chỉnh:** Sửa đổi giao diện để phù hợp với thương hiệu hoặc sở thích cá nhân.
+- **Truy cập API:** Mở rộng chức năng bằng cách sử dụng REST API được tài liệu hóa tốt.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Mã nguồn mở và Miễn phí:** Không có chi phí bản quyền, với toàn quyền truy cập mã nguồn.
+- **Tự lưu trữ:** Toàn quyền sở hữu và riêng tư dữ liệu.
+- **Linh hoạt Đa Lưu trữ:** Sử dụng kết hợp các backend lưu trữ một cách liền mạch.
+- **Nhẹ và Nhanh:** Được xây dựng bằng Go, đảm bảo hiệu suất cao với mức sử dụng tài nguyên thấp.
+- **Cộng đồng Tích cực:** Sự hiện diện mạnh mẽ trên GitHub với các bản cập nhật và hỗ trợ thường xuyên.
+
+**Nhược điểm:**
+- **Yêu cầu Tự lưu trữ:** Yêu cầu kiến thức kỹ thuật để triển khai và bảo trì.
+- **Hỗ trợ Di động Hạn chế:** Chức năng ứng dụng di động có thể không được trau chuốt như các lựa chọn thương mại.
+- **Khoảng trống Tài liệu:** Một số tính năng nâng cao có thể có tài liệu thưa thớt.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai Cloudreve trên máy chủ Ubuntu (khuyến nghị 22.04 LTS). Hướng dẫn này sử dụng Docker cho sự đơn giản và khả năng tái tạo.
+
+### Yêu cầu:
+- Máy chủ Ubuntu (22.04 LTS)
+- Docker và Docker Compose đã được cài đặt
+- Có kiến thức cơ bản về dòng lệnh Linux
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker && sudo systemctl start docker
+```
+
+### Bước 2: Tạo Thư mục cho Cloudreve
+```bash
+mkdir ~/cloudreve && cd ~/cloudreve
+```
+
+### Bước 3: Tạo Tệp Docker Compose
+Tạo một tệp `docker-compose.yml` với nội dung sau:
+
+```yaml
+version: '3.8'
+services:
+  cloudreve:
+    image: cloudreve/cloudreve:latest
+    container_name: cloudreve
+    restart: unless-stopped
+    ports:
+      - "5212:5212"
+    volumes:
+      - ./uploads:/cloudreve/uploads
+      - ./conf.ini:/cloudreve/conf.ini
+      - ./cloudreve.db:/cloudreve/cloudreve.db
+    environment:
+      - TZ=Asia/Shanghai  # Điều chỉnh theo múi giờ của bạn
+```
+
+### Bước 4: Triển khai Cloudreve
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 5: Truy cập và Cấu hình
+Sau khi triển khai, truy cập Cloudreve tại `http://your-server-ip:5212`. Tài khoản quản trị và mật khẩu ban đầu sẽ được hiển thị trong nhật ký container. Lấy chúng bằng:
+
+```bash
+sudo docker logs cloudreve
+```
+
+Đăng nhập, thay đổi mật khẩu mặc định và cấu hình các backend lưu trữ và cài đặt người dùng thông qua bảng quản trị web.
+
+### Bước 6 (Tùy chọn): Thiết lập Reverse Proxy
+Để sử dụng trong sản xuất, hãy thiết lập reverse proxy với Nginx hoặc Apache và SSL để truy cập an toàn.
+
+Thiết lập này cung cấp một phiên bản Cloudreve hoạt động. Đối với các cấu hình nâng cao, hãy tham khảo [tài liệu Cloudreve](https://docs.cloudreve.org/) chính thức.

--- a/src/content/posts/Self-host-coollabsio-coolify-vi.md
+++ b/src/content/posts/Self-host-coollabsio-coolify-vi.md
@@ -1,0 +1,103 @@
+---
+lang: vi
+title: "Đánh Giá Coolify: Giải Pháp Thay Thế Tự Lưu Trữ Tối Ưu Cho Heroku, Netlify và Vercel"
+description: "Khám phá Coolify, nền tảng mã nguồn mở để tự lưu trữ ứng dụng. Thay thế Heroku, Netlify và Vercel với toàn quyền kiểm soát việc triển khai của bạn."
+published: 2025-09-01
+tags: ['open-source', 'self-host', 'docker', 'devops', 'deployment', 'heroku-alternative']
+category: Self-hosted
+author: minhpt
+---
+
+# coollabsio/coolify - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/coollabsio/coolify](https://github.com/coollabsio/coolify)
+- **Sao:** 44499
+
+## 2. Mô Tả Dự Án
+
+Coolify là một nền tảng mã nguồn mở, có thể tự lưu trữ, đóng vai trò là giải pháp thay thế mạnh mẽ cho các nền tảng ứng dụng đám mây phổ biến như Heroku, Netlify và Vercel. Nó cho phép các nhà phát triển triển khai, quản lý và mở rộng ứng dụng một cách dễ dàng trong khi vẫn duy trì toàn quyền kiểm soát cơ sở hạ tầng của họ. Được xây dựng với sự đơn giản và linh hoạt trong tâm trí, Coolify hỗ trợ nhiều ngôn ngữ lập trình và framework, khiến nó trở thành lựa chọn lý tưởng cho cả nhà phát triển cá nhân và nhóm muốn giảm sự phụ thuộc vào dịch vụ bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Coolify được thiết kế để thay thế một số nền tảng triển khai thương mại và mã nguồn mở nổi tiếng, bao gồm:
+
+- **Heroku:** Cho triển khai ứng dụng dựa trên container và truyền thống.
+- **Netlify:** Cho lưu trữ trang web tĩnh và hàm serverless.
+- **Vercel:** Cho framework frontend và triển khai serverless.
+- **Platform.sh** và các giải pháp PaaS tương tự.
+
+Bằng cách cung cấp chức năng tương tự mà không bị khóa nhà cung cấp, Coolify trao quyền cho người dùng tự lưu trữ nền tảng triển khai của riêng họ trên cơ sở hạ tầng ưa thích.
+
+## 4. Chức Năng Chính
+
+Coolify cung cấp một bộ tính năng toàn diện cho việc triển khai và quản lý ứng dụng hiện đại:
+
+- **Hỗ trợ Đa Ngôn ngữ:** Triển khai ứng dụng viết bằng Node.js, Python, Ruby, PHP, Go, Java và hơn thế nữa.
+- **Quản lý Cơ sở dữ liệu:** Hỗ trợ tích hợp cho PostgreSQL, MySQL, Redis và các cơ sở dữ liệu khác.
+- **Lưu trữ Trang Tĩnh:** Lưu trữ hiệu quả các trang web tĩnh với SSL tự động và khả năng CDN.
+- **Hàm Serverless:** Chạy và mở rộng các hàm serverless một cách dễ dàng.
+- **Tích hợp Docker:** Hỗ trợ gốc cho container Docker, cho phép môi trường chạy tùy chỉnh.
+- **Đường ống CI/CD:** Tự động hóa kiểm thử và triển khai với tích hợp và phân phối liên tục.
+- **Giám sát và Nhật ký:** Giám sát ứng dụng thời gian thực, nhật ký và kiểm tra sức khỏe.
+- **Cộng tác Nhóm:** Kiểm soát truy cập dựa trên vai trò cho phát triển và triển khai theo nhóm.
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm:
+- **Tiết kiệm Chi phí:** Loại bỏ các khoản phí định kỳ liên quan đến nền tảng thương mại.
+- **Toàn quyền Kiểm soát:** Quyền sở hữu hoàn toàn cơ sở hạ tầng, dữ liệu và quy trình triển khai.
+- **Mã nguồn Mở:** Phát triển minh bạch, do cộng đồng thúc đẩy với các bản cập nhật thường xuyên.
+- **Linh hoạt:** Hỗ trợ nhiều công nghệ và cấu hình tùy chỉnh.
+- **Bảo mật Tự lưu trữ:** Tăng cường bảo mật bằng cách giữ dữ liệu nhạy cảm tại chỗ hoặc trong đám mây riêng.
+
+### Nhược điểm:
+- **Độ phức tạp Thiết lập Ban đầu:** Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì.
+- **Chi phí Bảo trì:** Người dùng chịu trách nhiệm về cập nhật, sao lưu và quản lý máy chủ.
+- **Dịch vụ Được Quản lý Hạn chế:** Thiếu một số dịch vụ được quản lý và tích hợp mà các lựa chọn thương mại cung cấp.
+- **Thách thức Mở rộng:** Mở rộng cơ sở hạ tầng thủ công có thể yêu cầu thêm chuyên môn DevOps.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Thực hiện theo các bước sau để triển khai Coolify trên máy chủ Ubuntu (22.04 LTS trở lên).
+
+### Yêu cầu:
+- Máy chủ chạy Ubuntu 22.04 LTS với ít nhất 2GB RAM và 20GB dung lượng đĩa.
+- Docker và Docker Compose đã được cài đặt.
+- Tên miền trỏ đến IP máy chủ của bạn (tùy chọn nhưng khuyến nghị cho HTTPS).
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt install docker-ce docker-ce-cli containerd.io -y
+```
+
+### Bước 2: Cài đặt Docker Compose
+```bash
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+### Bước 3: Triển khai Coolify
+Sao chép kho lưu trữ Coolify và bắt đầu triển khai:
+
+```bash
+git clone https://github.com/coollabsio/coolify.git
+cd coolify
+docker-compose up -d
+```
+
+### Bước 4: Truy cập Coolify
+Sau khi triển khai, truy cập bảng điều khiển Coolify qua `http://your-server-ip:3000`. Làm theo hướng dẫn trên màn hình để hoàn tất thiết lập ban đầu, bao gồm cấu hình tên miền và chứng chỉ SSL nếu muốn.
+
+### Bước 5: Triển khai Ứng dụng Đầu tiên của Bạn
+1. Trong bảng điều khiển Coolify, kết nối kho lưu trữ Git của bạn.
+2. Cấu hình cài đặt ứng dụng của bạn (buildpack, biến môi trường, v.v.).
+3. Triển khai và giám sát ứng dụng của bạn thông qua giao diện trực quan.
+
+Để biết thêm tùy chỉnh và cấu hình nâng cao, hãy tham khảo [tài liệu Coolify](https://coolify.io/docs) chính thức.

--- a/src/content/posts/Self-host-danny-avila-LibreChat-vi.md
+++ b/src/content/posts/Self-host-danny-avila-LibreChat-vi.md
@@ -1,0 +1,130 @@
+---
+lang: vi
+title: "LibreChat: Giải Pháp Thay Thế ChatGPT Mã Nguồn Mở Tối Ưu Cho Tự Lưu Trữ"
+description: "Khám phá LibreChat, bản sao ChatGPT nâng cao với hỗ trợ đa mô hình, xác thực an toàn và các tính năng AI mạnh mẽ cho tự lưu trữ. Hoàn hảo cho nhà phát triển và doanh nghiệp."
+published: 2025-09-09
+tags: ['open-source', 'self-host', 'chatgpt-alternative', 'ai-chat', 'docker', 'nodejs', 'langchain']
+category: Self-hosted
+author: minhpt
+---
+
+# danny-avila/LibreChat - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/danny-avila/LibreChat](https://github.com/danny-avila/LibreChat)
+- **Sao:** 29382
+
+## 2. Mô Tả Dự Án
+
+LibreChat là một bản sao mã nguồn mở, nâng cao của ChatGPT, cung cấp giải pháp thay thế mạnh mẽ, giàu tính năng cho người dùng muốn có nhiều quyền kiểm soát, quyền riêng tư và tính linh hoạt hơn. Nó hỗ trợ tích hợp với nhiều nhà cung cấp AI, bao gồm OpenAI, Anthropic, AWS, Azure, Groq, Mistral, Gemini và hơn thế nữa, cho phép chuyển đổi liền mạch giữa các mô hình. Với các khả năng như tác nhân AI, tìm kiếm tin nhắn, trình thông dịch mã, tạo hình ảnh DALL-E-3, hành động OpenAPI và xác thực đa người dùng an toàn, LibreChat được thiết kế cho cả nhà phát triển cá nhân và doanh nghiệp muốn tự lưu trữ một nền tảng trò chuyện AI mạnh mẽ.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+LibreChat là giải pháp thay thế hấp dẫn cho một số giải pháp trò chuyện AI thương mại và độc quyền, bao gồm:
+
+- Đăng ký ChatGPT Plus của OpenAI
+- Giao diện web Claude của Anthropic
+- Các dịch vụ chatbot AI trả phí khác từ các nhà cung cấp như Groq và Mistral
+- Các nền tảng trò chuyện doanh nghiệp mã nguồn đóng thiếu tùy chọn tự lưu trữ
+
+## 4. Chức Năng Chính
+
+LibreChat tự hào có một bộ tính năng phong phú, khiến nó trở thành một công cụ linh hoạt cho các tương tác do AI điều khiển:
+
+- **Hỗ trợ Đa Mô hình:** Chuyển đổi giữa OpenAI, Anthropic, AWS Bedrock, Azure OpenAI, Groq, Mistral, Gemini và các mô hình khác.
+- **Tác nhân AI & Tích hợp LangChain:** Tạo tác nhân hội thoại với khả năng suy luận và sử dụng công cụ nâng cao.
+- **Xác thực Đa Người dùng An toàn:** Kiểm soát truy cập dựa trên vai trò cho nhóm và tổ chức.
+- **Tìm kiếm Tin nhắn & Artifacts:** Dễ dàng truy xuất các cuộc trò chuyện trước đó và quản lý nội dung đã tạo.
+- **Trình Thông dịch Mã & Hàm:** Thực thi các đoạn mã và sử dụng các hàm tùy chỉnh trong trò chuyện.
+- **DALL-E-3 & Tạo Hình ảnh:** Tạo và thao tác hình ảnh trực tiếp trong cuộc trò chuyện.
+- **Hành động OpenAPI:** Kết nối với API bên ngoài để mở rộng chức năng.
+- **Cài đặt Trước & Tùy chỉnh:** Lưu và tái sử dụng cấu hình trò chuyện để nhất quán.
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm
+
+- **Mã nguồn Mở và Miễn phí:** Không có phí đăng ký; toàn quyền kiểm soát việc triển khai và dữ liệu.
+- **Hỗ trợ Mô hình Phong phú:** Linh hoạt sử dụng nhiều nhà cung cấp AI.
+- **Quyền riêng tư khi Tự lưu trữ:** Tất cả dữ liệu ở lại trên cơ sở hạ tầng của bạn, tăng cường bảo mật.
+- **Phát triển Tích cực:** Cập nhật thường xuyên và cộng đồng phản hồi nhanh.
+- **Giàu Tính năng:** Bao gồm các khả năng nâng cao như tác nhân, thực thi mã và tạo hình ảnh.
+
+### Nhược điểm
+
+- **Độ phức tạp khi Tự lưu trữ:** Yêu cầu kiến thức kỹ thuật để triển khai và bảo trì.
+- **Tốn nhiều Tài nguyên:** Có thể yêu cầu tài nguyên tính toán đáng kể, đặc biệt với nhiều mô hình hoặc sử dụng cao.
+- **Phụ thuộc vào API Bên ngoài:** Một số tính năng dựa vào dịch vụ bên thứ ba, có thể phát sinh chi phí hoặc có giới hạn sử dụng.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Thực hiện theo các bước sau để triển khai LibreChat trên máy chủ Ubuntu (hoặc bản phân phối Linux tương tự). Hướng dẫn này giả định bạn có kiến thức cơ bản về dòng lệnh và Docker.
+
+### Yêu cầu
+
+- Ubuntu 20.04 trở lên
+- Docker và Docker Compose đã được cài đặt
+- Node.js (v18 trở lên) – tùy chọn cho một số tùy chỉnh nhất định
+- Git
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Phụ thuộc
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y curl git
+```
+
+### Bước 2: Cài đặt Docker và Docker Compose
+
+```bash
+# Cài đặt Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Cài đặt Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+### Bước 3: Sao chép Kho lưu trữ LibreChat
+
+```bash
+git clone https://github.com/danny-avila/LibreChat.git
+cd LibreChat
+```
+
+### Bước 4: Cấu hình Biến Môi trường
+
+Sao chép tệp môi trường mẫu và tùy chỉnh nó:
+
+```bash
+cp .env.example .env
+nano .env
+```
+
+Cập nhật các biến chính như:
+
+- `OPENAI_API_KEY` (hoặc khóa cho các nhà cung cấp khác như Anthropic, AWS, v.v.)
+- `JWT_SECRET` cho xác thực
+- Cài đặt cơ sở dữ liệu và Redis (nếu sử dụng dịch vụ bên ngoài)
+
+### Bước 5: Khởi động Ứng dụng với Docker Compose
+
+```bash
+docker-compose up -d
+```
+
+Lệnh này sẽ kéo các image cần thiết và khởi động LibreChat ở chế độ nền.
+
+### Bước 6: Truy cập LibreChat
+
+Sau khi các container đang chạy, truy cập ứng dụng tại `http://your-server-ip:3080` (thay thế bằng địa chỉ IP máy chủ của bạn). Bạn có thể tạo tài khoản và bắt đầu sử dụng LibreChat ngay lập tức.
+
+### Lưu ý Bổ sung
+
+- Để sử dụng trong sản xuất, hãy cân nhắc sử dụng reverse proxy (ví dụ: Nginx) với SSL.
+- Theo dõi mức sử dụng tài nguyên, vì các mô hình AI có thể tốn nhiều tài nguyên tính toán.
+- Thường xuyên cập nhật kho lưu trữ để hưởng lợi từ các tính năng mới nhất và bản vá bảo mật.
+
+Để biết cấu hình chi tiết hơn hoặc khắc phục sự cố, hãy tham khảo [tài liệu LibreChat](https://github.com/danny-avila/LibreChat/wiki) chính thức.

--- a/src/content/posts/Self-host-glanceapp-glance-vi.md
+++ b/src/content/posts/Self-host-glanceapp-glance-vi.md
@@ -1,0 +1,110 @@
+---
+lang: vi
+title: "GlanceApp/Glance: Bảng Điều Khiển Tự Lưu Trữ Tối Ưu Cho Tất Cả Nguồn Cấp Dữ Liệu Của Bạn"
+description: "Khám phá glanceapp/glance, một bảng điều khiển tự lưu trữ mạnh mẽ tập trung tất cả nguồn cấp dữ liệu của bạn. Tìm hiểu các tính năng, ưu nhược điểm và cách cài đặt."
+published: 2025-09-12
+tags: ['open-source', 'self-host', 'dashboard', 'rss', 'feeds', 'docker', 'go']
+category: Self-hosted
+author: minhpt
+---
+
+# glanceapp/glance - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/glanceapp/glance](https://github.com/glanceapp/glance)
+- **Sao:** 27270
+
+## 2. Mô Tả Dự Án
+Glance là một bảng điều khiển tự lưu trữ được thiết kế để tổng hợp và hiển thị tất cả các nguồn cấp dữ liệu của bạn trong một giao diện thống nhất. Cho dù bạn đang theo dõi nguồn cấp RSS, cập nhật mạng xã hội hay nội dung web khác, Glance cung cấp một giải pháp sạch sẽ, có thể tùy chỉnh và tập trung vào quyền riêng tư. Nó cho phép người dùng hợp nhất thông tin từ nhiều nguồn, giúp bạn dễ dàng cập nhật mà không phụ thuộc vào dịch vụ bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Glance có thể là giải pháp thay thế cho một số dịch vụ tổng hợp nguồn cấp dữ liệu và bảng điều khiển phổ biến, bao gồm:
+- Feedly (cho nguồn cấp RSS và tin tức)
+- TweetDeck (cho theo dõi mạng xã hội)
+- Hootsuite hoặc Buffer (cho bảng điều khiển mạng xã hội)
+- Netvibes hoặc iGoogle (cho bảng điều khiển web cá nhân hóa)
+- Các công cụ giám sát thương mại như Datadog hoặc Grafana (cho các trường hợp sử dụng dựa trên nguồn cấp dữ liệu đơn giản hơn)
+
+## 4. Chức Năng Chính
+Glance cung cấp một loạt các tính năng để nâng cao trải nghiệm quản lý nguồn cấp dữ liệu của bạn:
+- **Tích hợp Đa Nguồn:** Hỗ trợ nguồn cấp RSS, Atom, JSON và các nền tảng mạng xã hội.
+- **Bố cục Tùy chỉnh:** Widget kéo và thả để tổ chức bảng điều khiển của bạn.
+- **Cập nhật Thời gian thực:** Tự động làm mới nguồn cấp dữ liệu để giữ thông tin luôn cập nhật.
+- **Tập trung vào Quyền riêng tư:** Tất cả dữ liệu được lưu trữ cục bộ, đảm bảo thông tin của bạn vẫn riêng tư.
+- **Chủ đề và Tùy chỉnh:** Cung cấp nhiều chủ đề và tùy chọn tùy chỉnh cho giao diện cá nhân hóa.
+- **Đáp ứng Di động:** Truy cập bảng điều khiển của bạn trên bất kỳ thiết bị nào với thiết kế đáp ứng.
+
+## 5. Ưu và Nhược Điểm
+### Ưu điểm:
+- **Mã nguồn Mở:** Miễn phí sử dụng, sửa đổi và phân phối.
+- **Tự lưu trữ:** Toàn quyền kiểm soát dữ liệu và việc triển khai của bạn.
+- **Nhẹ và Nhanh:** Được xây dựng với hiệu quả, sử dụng Go cho hiệu suất backend.
+- **Có thể Mở rộng:** Dễ dàng thêm các loại nguồn cấp dữ liệu mới hoặc tích hợp thông qua plugin.
+- **Hỗ trợ Cộng đồng:** Phát triển tích cực và cộng đồng người dùng đang phát triển.
+
+### Nhược điểm:
+- **Thiết lập Ban đầu:** Yêu cầu kiến thức kỹ thuật để tự lưu trữ.
+- **Tích hợp Sẵn có Hạn chế:** Mặc dù có thể mở rộng, hỗ trợ sẵn có cho một số nền tảng có thể bị hạn chế.
+- **Bảo trì:** Các giải pháp tự lưu trữ yêu cầu cập nhật và quản lý máy chủ liên tục.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai Glance trên máy chủ Ubuntu:
+
+### Yêu cầu:
+- Máy chủ chạy Ubuntu 20.04 trở lên.
+- Docker và Docker Compose đã được cài đặt.
+- Có kiến thức cơ bản về thao tác dòng lệnh.
+
+### Bước 1: Cập nhật Hệ thống của Bạn
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+### Bước 2: Cài đặt Docker và Docker Compose
+```bash
+# Cài đặt Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Cài đặt Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+### Bước 3: Tạo Thư mục cho Glance
+```bash
+mkdir glance && cd glance
+```
+
+### Bước 4: Tạo Tệp Docker Compose
+Tạo một tệp `docker-compose.yml` với nội dung sau:
+
+```yaml
+version: '3.8'
+services:
+  glance:
+    image: glanceapp/glance:latest
+    container_name: glance
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped
+```
+
+### Bước 5: Triển khai Glance
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 6: Truy cập Glance
+Mở trình duyệt web của bạn và điều hướng đến `http://your-server-ip:3000`. Làm theo hướng dẫn trên màn hình để thiết lập bảng điều khiển của bạn và thêm nguồn cấp dữ liệu.
+
+### Cấu hình Bổ sung:
+- Để sử dụng tên miền tùy chỉnh hoặc HTTPS, hãy cân nhắc sử dụng reverse proxy như Nginx hoặc Traefik.
+- Thường xuyên cập nhật container để có các tính năng mới nhất và bản vá bảo mật:
+  ```bash
+  sudo docker-compose pull && sudo docker-compose up -d
+  ```
+
+Để biết thêm chi tiết, hãy tham khảo [tài liệu Glance](https://github.com/glanceapp/glance) chính thức.

--- a/src/content/posts/Self-host-go-gitea-gitea-vi.md
+++ b/src/content/posts/Self-host-go-gitea-gitea-vi.md
@@ -1,0 +1,170 @@
+---
+lang: vi
+title: "Gitea: Giải Pháp Git Tự Lưu Trữ Tối Ưu - Đánh Giá Hoàn Chỉnh và Hướng Dẫn Thiết Lập"
+description: "Khám phá Gitea, nền tảng lưu trữ Git mã nguồn mở với hơn 50k sao GitHub. Tìm hiểu cách tự lưu trữ giải pháp thay thế GitHub của riêng bạn với hướng dẫn cài đặt chi tiết."
+published: 2025-08-29
+tags: ['open-source', 'self-host', 'git', 'golang', 'devops', 'ci-cd']
+category: Self-hosted
+author: minhpt
+---
+
+# go-gitea/gitea - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/go-gitea/gitea](https://github.com/go-gitea/gitea)
+- **Sao:** 50281
+
+## 2. Mô Tả Dự Án
+
+Gitea là một dịch vụ Git tự lưu trữ dễ dàng, được viết bằng Go. Nó cung cấp một nền tảng phát triển phần mềm hoàn chỉnh bao gồm lưu trữ Git, đánh giá mã, cộng tác nhóm, kho lưu trữ gói và khả năng CI/CD. Được thiết kế để nhẹ và dễ triển khai, Gitea cung cấp một giải pháp thay thế hấp dẫn cho các dịch vụ lưu trữ Git thương mại trong khi vẫn cho bạn toàn quyền kiểm soát mã và cơ sở hạ tầng của mình.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Gitea là giải pháp thay thế trực tiếp cho:
+- GitHub (phiên bản tự lưu trữ)
+- GitLab Community Edition
+- Bitbucket Server
+- Gogs (từ đó Gitea được fork)
+- Các giải pháp lưu trữ Git độc quyền khác
+
+## 4. Chức Năng Chính
+
+Gitea cung cấp một bộ tính năng toàn diện bao gồm:
+
+**Lưu trữ Git:**
+- Quản lý kho lưu trữ Git đầy đủ
+- Hỗ trợ SSH và HTTP/HTTPS
+- Quy tắc bảo vệ nhánh
+- Webhook và truy cập API
+
+**Công cụ Cộng tác:**
+- Theo dõi vấn đề với milestone và nhãn
+- Pull request với đánh giá mã
+- Hệ thống tài liệu Wiki
+- Bảng dự án (kiểu Kanban)
+
+**Tính năng Bổ sung:**
+- Kho lưu trữ gói tích hợp (hỗ trợ nhiều định dạng)
+- Hệ thống CI/CD tích hợp
+- Quản lý người dùng và tổ chức
+- Nhiều phương pháp xác thực (OAuth, LDAP, SMTP)
+- Giao diện đa ngôn ngữ
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Cực kỳ nhẹ và nhanh (được viết bằng Go)
+- Tiêu thụ tài nguyên thấp so với các lựa chọn thay thế
+- Dễ triển khai và bảo trì
+- Cộng đồng tích cực và cập nhật thường xuyên
+- Bộ tính năng toàn diện
+- Miễn phí và mã nguồn mở
+- Hỗ trợ Docker
+
+**Nhược điểm:**
+- Hệ sinh thái nhỏ hơn so với GitHub/GitLab
+- Ít tích hợp bên thứ ba hơn
+- Các tính năng doanh nghiệp có thể yêu cầu cấu hình bổ sung
+- Cộng đồng mặc định nhỏ hơn so với các lựa chọn thương mại
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04/22.04 LTS
+- Tối thiểu 1GB RAM (khuyến nghị 2GB)
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến máy chủ của bạn
+
+### Cài đặt Từng bước
+
+**1. Cập nhật Gói Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+**2. Cài đặt Docker**
+```bash
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable --now docker
+```
+
+**3. Tạo Tệp Docker Compose**
+Tạo `docker-compose.yml`:
+```yaml
+version: '3'
+
+services:
+  server:
+    image: gitea/gitea:latest
+    container_name: gitea
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - DB_TYPE=sqlite3
+    restart: always
+    volumes:
+      - ./gitea:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "3000:3000"
+      - "2222:22"
+```
+
+**4. Triển khai Gitea**
+```bash
+mkdir gitea
+docker-compose up -d
+```
+
+**5. Cấu hình Gitea**
+Truy cập máy chủ của bạn tại `http://your-server-ip:3000` và hoàn tất thiết lập ban đầu:
+- Đặt cơ sở dữ liệu thành SQLite3
+- Cấu hình tên miền và cài đặt SSH
+- Tạo tài khoản quản trị
+
+**6. Thiết lập Reverse Proxy (Tùy chọn nhưng Khuyến nghị)**
+Cài đặt Nginx:
+```bash
+sudo apt install nginx -y
+```
+
+Tạo cấu hình Nginx tại `/etc/nginx/sites-available/gitea`:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Kích hoạt site:
+```bash
+sudo ln -s /etc/nginx/sites-available/gitea /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+**7. Chứng chỉ SSL (Khuyến nghị)**
+Cài đặt Certbot:
+```bash
+sudo apt install certbot python3-certbot-nginx -y
+sudo certbot --nginx -d your-domain.com
+```
+
+Phiên bản Gitea của bạn hiện đã sẵn sàng! Bạn có thể bắt đầu tạo kho lưu trữ, mời thành viên nhóm và tận hưởng giải pháp Git tự lưu trữ của mình.
+
+### Bảo trì
+- Sao lưu định kỳ: Sao lưu thư mục `./gitea`
+- Cập nhật: `docker-compose pull && docker-compose up -d`
+- Giám sát nhật ký: `docker logs gitea`
+
+Gitea cung cấp sự cân bằng tuyệt vời giữa tính năng và hiệu suất, khiến nó trở thành lựa chọn lý tưởng cho các nhóm và cá nhân tìm kiếm giải pháp Git tự lưu trữ.

--- a/src/content/posts/Self-host-gogs-gogs-vi.md
+++ b/src/content/posts/Self-host-gogs-gogs-vi.md
@@ -1,0 +1,155 @@
+---
+lang: vi
+title: "Gogs: Dịch Vụ Git Tự Lưu Trữ Tối Ưu - Hướng Dẫn Hoàn Chỉnh"
+description: "Khám phá Gogs, dịch vụ Git tự lưu trữ nhẹ nhàng, dễ dàng. Tìm hiểu cách triển khai, tính năng, ưu nhược điểm và tại sao nó là giải pháp thay thế hàng đầu cho GitHub."
+published: 2025-08-31
+tags: ['open-source', 'self-host', 'git', 'golang', 'docker', 'devops']
+category: Self-hosted
+author: minhpt
+---
+
+# gogs/gogs - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/gogs/gogs](https://github.com/gogs/gogs)
+- **Sao:** 46802
+
+## 2. Mô Tả Dự Án
+
+Gogs (Go Git Service) là một dịch vụ Git mã nguồn mở, tự lưu trữ được viết bằng Go. Nó cung cấp giải pháp thay thế nhẹ, nhanh và thân thiện với người dùng cho các nền tảng như GitHub và GitLab, với mức sử dụng tài nguyên tối thiểu. Được thiết kế cho sự đơn giản và dễ sử dụng, Gogs cung cấp các công cụ quản lý kho lưu trữ Git, theo dõi vấn đề và cộng tác thiết yếu mà không có sự phức tạp hoặc chi phí của các giải pháp lớn hơn.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Gogs là giải pháp thay thế khả thi cho:
+
+- GitHub (tự lưu trữ/Doanh nghiệp)
+- GitLab (tự lưu trữ/Community Edition)
+- Bitbucket Server
+- Gitea (một fork của Gogs với các tính năng bổ sung)
+
+## 4. Chức Năng Chính
+
+Các tính năng chính của Gogs bao gồm:
+
+- Lưu trữ kho lưu trữ Git với hỗ trợ HTTP/SSH
+- Theo dõi vấn đề và milestone
+- Pull request và đánh giá mã
+- Quản lý người dùng và tổ chức
+- Webhook và tích hợp
+- Wiki tích hợp và trình soạn thảo tệp
+- Hỗ trợ đa ngôn ngữ
+- Nhẹ và nhanh, ngay cả trên hệ thống tài nguyên thấp
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Cực kỳ nhẹ và tiết kiệm tài nguyên
+- Thiết lập và cấu hình đơn giản
+- Giao diện người dùng trực quan, sạch sẽ
+- Cộng đồng tích cực và cập nhật thường xuyên
+- Hỗ trợ nhiều cơ sở dữ liệu (SQLite, MySQL, PostgreSQL)
+- Hỗ trợ Docker để triển khai dễ dàng
+
+**Nhược điểm:**
+- Thiếu một số tính năng nâng cao có trong GitLab (ví dụ: tích hợp CI/CD)
+- Hệ sinh thái plugin/tiện ích mở rộng nhỏ hơn so với GitHub/GitLab
+- Tự động hóa tích hợp hạn chế so với các lựa chọn thương mại
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Hướng dẫn này bao gồm việc triển khai Gogs trên máy chủ Ubuntu 22.04 bằng Docker để đơn giản và đáng tin cậy.
+
+### Yêu cầu:
+- Máy chủ Ubuntu 22.04
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến máy chủ của bạn (tùy chọn nhưng khuyến nghị cho sản xuất)
+
+### Bước 1: Cài đặt Docker và Docker Compose
+Cập nhật hệ thống và cài đặt Docker:
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker && sudo systemctl start docker
+```
+
+### Bước 2: Tạo Tệp Docker Compose
+Tạo thư mục cho Gogs và điều hướng vào đó:
+```bash
+mkdir gogs && cd gogs
+```
+
+Tạo một tệp `docker-compose.yml`:
+```yaml
+version: '3'
+
+services:
+  gogs:
+    image: gogs/gogs
+    container_name: gogs
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+      - "10022:22"
+    volumes:
+      - ./data:/data
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+```
+
+### Bước 3: Triển khai Gogs
+Khởi động container với:
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 4: Cấu hình Gogs
+Mở trình duyệt và đi đến `http://your-server-ip:3000` (thay thế bằng tên miền của bạn nếu đã cấu hình). Làm theo trình hướng dẫn thiết lập:
+
+1. **Cài đặt Cơ sở dữ liệu:** Sử dụng SQLite3 (mặc định, được lưu trữ trong `/data`).
+2. **Cài đặt Chung:** Đặt URL ứng dụng, ví dụ: `http://your-domain.com:3000`.
+3. **Tài khoản Quản trị:** Tạo người dùng quản trị.
+4. Hoàn tất cài đặt.
+
+### Bước 5 (Tùy chọn): Thiết lập Reverse Proxy (Nginx)
+Để sử dụng trong sản xuất, hãy thiết lập Nginx làm reverse proxy. Cài đặt Nginx:
+```bash
+sudo apt install nginx -y
+```
+
+Tạo một tệp cấu hình mới:
+```bash
+sudo nano /etc/nginx/sites-available/gogs
+```
+
+Thêm nội dung sau, thay thế `your-domain.com` bằng tên miền thực tế của bạn:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Kích hoạt site và khởi động lại Nginx:
+```bash
+sudo ln -s /etc/nginx/sites-available/gogs /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl restart nginx
+```
+
+### Bước 6: Bảo mật với SSL (Tùy chọn nhưng Khuyến nghị)
+Sử dụng Let's Encrypt để thêm HTTPS:
+```bash
+sudo apt install certbot python3-certbot-nginx -y
+sudo certbot --nginx -d your-domain.com
+```
+
+Phiên bản Gogs của bạn hiện đã hoạt động và có thể truy cập một cách an toàn!
+
+Để biết thêm tùy chỉnh, hãy tham khảo [tài liệu Gogs](https://gogs.io/docs) chính thức.

--- a/src/content/posts/Self-host-immich-app-immich-vi.md
+++ b/src/content/posts/Self-host-immich-app-immich-vi.md
@@ -1,0 +1,152 @@
+---
+lang: vi
+title: "Đánh Giá Immich: Giải Pháp Quản Lý Ảnh & Video Tự Lưu Trữ Tối Ưu"
+description: "Khám phá Immich, giải pháp thay thế mã nguồn mở, tự lưu trữ cho Google Photos với hơn 74k sao GitHub. Tìm hiểu tính năng, cách cài đặt và ưu nhược điểm."
+published: 2025-08-27
+tags: ['open-source', 'self-host', 'photo-management', 'video-backup', 'docker', 'typescript', 'nodejs']
+category: Self-hosted
+author: minhpt
+---
+
+# immich-app/immich - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/immich-app/immich](https://github.com/immich-app/immich)
+- **Sao:** 74087
+
+## 2. Mô Tả Dự Án
+
+Immich là một giải pháp quản lý ảnh và video hiệu suất cao, tự lưu trữ được thiết kế để cung cấp giải pháp thay thế riêng tư cho các dịch vụ đám mây như Google Photos. Nó cung cấp khả năng sao lưu an toàn, tổ chức và chia sẻ trong khi vẫn giữ toàn quyền kiểm soát thư viện phương tiện của bạn trên phần cứng của riêng bạn.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Immich là giải pháp thay thế trực tiếp cho:
+- Google Photos
+- Apple iCloud Photos
+- Amazon Photos
+- Các dịch vụ ảnh đám mây độc quyền khác
+
+Nó cũng bổ sung hoặc thay thế các giải pháp thay thế tự lưu trữ như:
+- Nextcloud Memories
+- PhotoPrism
+- Lychee
+
+## 4. Chức Năng Chính
+
+- **Sao lưu Tự động:** Tải lên ảnh/video liên tục từ thiết bị di động
+- **Nhận diện Khuôn mặt:** Nhận diện và nhóm khuôn mặt bằng AI
+- **Phát hiện Đối tượng:** Tìm kiếm thông minh sử dụng học máy
+- **Chế độ xem Dòng thời gian:** Sắp xếp phương tiện theo trình tự thời gian
+- **Quản lý Album:** Tạo và chia sẻ album tùy chỉnh
+- **Bảo toàn Metadata:** Duy trì dữ liệu EXIF và chất lượng gốc
+- **Hỗ trợ Nhiều Người dùng:** Khả năng tài khoản gia đình/dùng chung
+- **Ứng dụng Web & Di động:** Truy cập đa nền tảng
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Toàn quyền sở hữu và riêng tư dữ liệu
+- Không có phí đăng ký hoặc giới hạn lưu trữ
+- Phát triển tích cực với các bản cập nhật thường xuyên
+- Trải nghiệm ứng dụng di động tuyệt vời
+- Hỗ trợ cộng đồng mạnh mẽ
+- Triển khai dựa trên Docker giúp đơn giản hóa thiết lập
+
+**Nhược điểm:**
+- Yêu cầu kiến thức kỹ thuật để tự lưu trữ
+- Yêu cầu phần cứng cho các tính năng AI có thể khắt khe
+- Không có sao lưu từ xa tích hợp (phải cấu hình riêng)
+- Sử dụng pin ứng dụng di động trong quá trình sao lưu liên tục
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+
+- Docker và Docker Compose đã được cài đặt
+- Tối thiểu 2GB RAM (khuyến nghị 4GB+ cho các tính năng AI)
+- Tên miền với chứng chỉ SSL (khuyến nghị)
+
+### Cài đặt Từng bước
+
+1. **Cài đặt Docker và Docker Compose**
+```bash
+sudo apt update
+sudo apt install docker.io docker-compose
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+2. **Tạo Thư mục Dự án**
+```bash
+mkdir immich && cd immich
+```
+
+3. **Tải Tệp Docker Compose**
+```bash
+wget -O docker-compose.yml https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+```
+
+4. **Tạo Tệp Môi trường**
+```bash
+cat > .env << EOF
+DB_HOSTNAME=immich_postgres
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_DATABASE_NAME=immich
+REDIS_HOSTNAME=immich_redis
+UPLOAD_LOCATION=/usr/src/app/upload
+JWT_SECRET=$(openssl rand -base64 128)
+EOF
+```
+
+5. **Tạo Thư mục Tải lên**
+```bash
+mkdir -p upload
+sudo chown -R 1000:1000 upload
+```
+
+6. **Khởi động Dịch vụ Immich**
+```bash
+docker-compose up -d
+```
+
+7. **Truy cập Immich**
+Mở trình duyệt và điều hướng đến `http://your-server-ip:2283`
+
+### Cấu hình Bổ sung
+
+**Thiết lập Reverse Proxy (Nginx)**
+```bash
+sudo apt install nginx
+sudo nano /etc/nginx/sites-available/immich
+```
+
+Thêm cấu hình:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+    
+    location / {
+        proxy_pass http://localhost:2283;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Kích hoạt site:
+```bash
+sudo ln -s /etc/nginx/sites-available/immich /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+**Thiết lập SSL với Let's Encrypt**
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d your-domain.com
+```
+
+Phiên bản Immich của bạn hiện đã sẵn sàng! Tải ứng dụng di động từ cửa hàng ứng dụng của bạn và kết nối với máy chủ tự lưu trữ để bắt đầu sao lưu ảnh và video của bạn một cách an toàn.

--- a/src/content/posts/Self-host-juanfont-headscale-vi.md
+++ b/src/content/posts/Self-host-juanfont-headscale-vi.md
@@ -1,0 +1,110 @@
+---
+lang: vi
+title: "Headscale: Máy Chủ Điều Khiển Tailscale Tự Lưu Trữ Bạn Cần Năm 2025"
+description: "Khám phá juanfont/headscale, giải pháp thay thế mã nguồn mở, tự lưu trữ cho máy chủ điều khiển của Tailscale. Tìm hiểu tính năng, cách cài đặt và lợi ích."
+published: 2025-09-08
+tags: ['open-source', 'self-host', 'vpn', 'wireguard', 'networking', 'devops']
+category: Self-hosted
+author: minhpt
+---
+
+# juanfont/headscale - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/juanfont/headscale](https://github.com/juanfont/headscale)
+- **Sao:** 30667
+
+## 2. Mô Tả Dự Án
+Headscale là một bản triển khai mã nguồn mở, tự lưu trữ của máy chủ điều khiển Tailscale. Nó cho phép người dùng tạo và quản lý mạng riêng của riêng họ bằng ứng dụng khách Tailscale, mà không phụ thuộc vào cơ sở hạ tầng đám mây của Tailscale. Điều này cung cấp khả năng kiểm soát, quyền riêng tư và tùy chỉnh cao hơn cho các cá nhân và tổ chức muốn triển khai mạng lưới an toàn.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Headscale là giải pháp thay thế tự lưu trữ cho:
+- Máy chủ điều khiển chính thức của Tailscale (phiên bản SaaS)
+- Các giải pháp VPN thương mại như OpenVPN Access Server hoặc dịch vụ được quản lý của WireGuard
+- Các giải pháp mạng lưới độc quyền khác yêu cầu phụ thuộc vào đám mây
+
+## 4. Chức Năng Chính
+Các tính năng chính của Headscale bao gồm:
+- **Quản lý người dùng và máy:** Đăng ký và quản lý người dùng và thiết bị trong mạng của bạn.
+- **Danh sách kiểm soát truy cập (ACL):** Xác định các chính sách chi tiết cho lưu lượng mạng.
+- **Cấu hình DNS:** Tích hợp cài đặt DNS tùy chỉnh cho mạng riêng của bạn.
+- **Hỗ trợ đa nền tảng:** Tương thích với ứng dụng khách Tailscale trên Linux, macOS, Windows, iOS và Android.
+- **Điều khiển qua API:** Cung cấp REST API để tự động hóa và tích hợp với các công cụ khác.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Toàn quyền kiểm soát cơ sở hạ tầng mạng của bạn.
+- Quyền riêng tư được nâng cao vì không có dữ liệu nào được gửi đến máy chủ bên thứ ba.
+- Tiết kiệm chi phí cho các tổ chức có nhiều thiết bị.
+- Cộng đồng mã nguồn mở tích cực với các bản cập nhật thường xuyên.
+
+**Nhược điểm:**
+- Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì.
+- Trách nhiệm tự lưu trữ bao gồm bảo mật, cập nhật và sao lưu.
+- Thiếu một số tính năng doanh nghiệp có trong các gói trả phí của Tailscale.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai Headscale trên máy chủ Ubuntu:
+
+### Yêu cầu
+- Ubuntu 22.04 LTS trở lên
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến IP máy chủ của bạn (tùy chọn nhưng khuyến nghị cho HTTPS)
+
+### Bước 1: Cài đặt Docker và Docker Compose
+```bash
+sudo apt update && sudo apt install -y docker.io docker-compose
+sudo systemctl enable --now docker
+```
+
+### Bước 2: Tạo Thư mục cho Headscale
+```bash
+mkdir headscale && cd headscale
+```
+
+### Bước 3: Tạo Tệp Docker Compose
+Tạo một tệp `docker-compose.yml` với nội dung sau:
+
+```yaml
+version: '3.8'
+services:
+  headscale:
+    image: headscale/headscale:latest
+    container_name: headscale
+    volumes:
+      - ./config:/etc/headscale
+      - ./data:/var/lib/headscale
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+```
+
+### Bước 4: Tạo Cấu hình
+```bash
+docker run --rm -it -v $(pwd)/config:/etc/headscale headscale/headscale:latest generate
+```
+
+### Bước 5: Chỉnh sửa Cấu hình
+Chỉnh sửa `config/config.yaml` để đặt URL máy chủ và các tùy chọn khác. Ví dụ:
+```yaml
+server_url: http://your-domain.com:8080
+```
+
+### Bước 6: Khởi động Headscale
+```bash
+docker-compose up -d
+```
+
+### Bước 7: Tạo Người dùng và Khóa Pre-Auth
+```bash
+docker exec headscale headscale users create myuser
+docker exec headscale headscale preauthkeys create --user myuser --reusable --expiration 24h
+```
+
+### Bước 8: Kết nối Ứng dụng khách
+Sử dụng khóa pre-auth để kết nối ứng dụng khách Tailscale với máy chủ Headscale của bạn. Ví dụ, trên Linux:
+```bash
+tailscale up --login-server=http://your-server-ip:8080 --authkey=YOUR_AUTH_KEY
+```
+
+Phiên bản Headscale tự lưu trữ của bạn hiện đang chạy! Đối với các cấu hình nâng cao, như HTTPS hoặc thiết lập cơ sở dữ liệu, hãy tham khảo [tài liệu chính thức](https://github.com/juanfont/headscale).

--- a/src/content/posts/Self-host-karakeep-app-karakeep-vi.md
+++ b/src/content/posts/Self-host-karakeep-app-karakeep-vi.md
@@ -1,0 +1,99 @@
+---
+lang: vi
+title: "KaraKeep: Ứng Dụng Đánh Dấu Trang Tự Lưu Trữ Tối Ưu với Gắn Thẻ AI"
+description: "Khám phá KaraKeep, giải pháp đánh dấu trang có thể tự lưu trữ mạnh mẽ với gắn thẻ dựa trên AI, tìm kiếm toàn văn và hỗ trợ liên kết, ghi chú và hình ảnh."
+published: 2025-09-17
+tags: ['open-source', 'self-host', 'bookmarking', 'AI', 'docker', 'nodejs', 'react']
+category: Self-hosted
+author: minhpt
+---
+
+# karakeep-app/karakeep - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/karakeep-app/karakeep](https://github.com/karakeep-app/karakeep)
+- **Sao:** 19326
+
+## 2. Mô Tả Dự Án
+KaraKeep là một ứng dụng đánh dấu trang sáng tạo, có thể tự lưu trữ, cho phép người dùng lưu và tổ chức nhiều loại nội dung khác nhau—bao gồm liên kết web, ghi chú cá nhân và hình ảnh—với sức mạnh bổ sung của gắn thẻ tự động bằng AI và tìm kiếm toàn văn toàn diện. Được thiết kế cho người dùng và tổ chức có ý thức về quyền riêng tư, nó cung cấp một giải pháp thay thế hiện đại cho các dịch vụ đánh dấu trang đám mây bằng cách cho phép kiểm soát hoàn toàn dữ liệu.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+KaraKeep là giải pháp thay thế mạnh mẽ cho một số công cụ đánh dấu trang thương mại và mã nguồn mở phổ biến, bao gồm:
+- Pocket
+- Raindrop.io
+- Evernote (cho các tính năng lưu ghi chú)
+- Pinboard
+- Instapaper
+- Bất kỳ trình quản lý đánh dấu trang đám mây nào thiếu tùy chọn tự lưu trữ
+
+## 4. Chức Năng Chính
+Các tính năng chính của KaraKeep bao gồm:
+- **Hỗ trợ Đa Định dạng:** Lưu liên kết, ghi chú và hình ảnh trong một nền tảng thống nhất.
+- **Gắn Thẻ bằng AI:** Tự động tạo thẻ liên quan bằng học máy, giảm công sức tổ chức thủ công.
+- **Tìm kiếm Toàn văn:** Nhanh chóng định vị nội dung đã lưu với khả năng tìm kiếm mạnh mẽ.
+- **Triển khai Tự lưu trữ:** Toàn quyền sở hữu và riêng tư dữ liệu với lưu trữ tại chỗ hoặc đám mây riêng.
+- **Giao diện Thân thiện:** Giao diện hiện đại, đáp ứng được xây dựng bằng React để sử dụng liền mạch trên nhiều thiết bị.
+- **Truy cập API:** Mở rộng chức năng và tích hợp với các công cụ khác bằng API được tài liệu hóa tốt.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Tập trung vào quyền riêng tư với khả năng tự lưu trữ.
+- Gắn thẻ AI tiết kiệm thời gian và cải thiện tổ chức.
+- Hỗ trợ nhiều loại nội dung (liên kết, ghi chú, hình ảnh).
+- Cộng đồng mã nguồn mở tích cực với các bản cập nhật thường xuyên.
+- Không phụ thuộc vào dịch vụ bên thứ ba cho các chức năng cốt lõi.
+
+**Nhược điểm:**
+- Yêu cầu kiến thức kỹ thuật để tự lưu trữ và bảo trì.
+- Các tính năng AI có thể cần tinh chỉnh cho các trường hợp sử dụng cụ thể.
+- Thiếu một số tính năng cộng tác nâng cao có trong các lựa chọn thương mại.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai KaraKeep trên máy chủ Ubuntu (khuyến nghị 22.04 LTS):
+
+### Yêu cầu:
+- Máy chủ Ubuntu (có quyền sudo)
+- Docker và Docker Compose đã được cài đặt
+- Git
+
+### Hướng dẫn Từng bước:
+
+1. **Cập nhật Hệ thống và Cài đặt Docker:**
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   sudo apt install docker.io docker-compose -y
+   sudo systemctl enable docker && sudo systemctl start docker
+   ```
+
+2. **Sao chép Kho lưu trữ:**
+   ```bash
+   git clone https://github.com/karakeep-app/karakeep.git
+   cd karakeep
+   ```
+
+3. **Cấu hình Môi trường:**
+   Sao chép tệp môi trường mẫu và sửa đổi khi cần:
+   ```bash
+   cp .env.example .env
+   nano .env
+   ```
+   Điều chỉnh các cài đặt như thông tin đăng nhập cơ sở dữ liệu, khóa bí mật và cấu hình cổng.
+
+4. **Xây dựng và Khởi động với Docker Compose:**
+   ```bash
+   sudo docker-compose up -d
+   ```
+
+5. **Xác minh Triển khai:**
+   Kiểm tra xem các container có đang chạy không:
+   ```bash
+   sudo docker ps
+   ```
+   Truy cập KaraKeep bằng cách điều hướng đến `http://your-server-ip:3000` (cổng mặc định).
+
+6. **Tùy chọn: Thiết lập Reverse Proxy (Nginx):**
+   Để sử dụng trong sản xuất, hãy thiết lập Nginx làm reverse proxy cho SSL và định tuyến tên miền.
+
+Để biết các tùy chọn cấu hình chi tiết và khắc phục sự cố, hãy tham khảo [tài liệu chính thức](https://github.com/karakeep-app/karakeep/wiki).
+
+Tận hưởng giải pháp đánh dấu trang tự lưu trữ, hỗ trợ AI của bạn với KaraKeep!

--- a/src/content/posts/Self-host-khoj-ai-khoj-vi.md
+++ b/src/content/posts/Self-host-khoj-ai-khoj-vi.md
@@ -1,0 +1,96 @@
+---
+lang: vi
+title: "Khoj AI: Bộ Não Thứ Hai AI Tự Lưu Trữ Của Bạn - Đánh Giá Hoàn Chỉnh"
+description: "Khám phá Khoj AI, trợ lý AI mã nguồn mở, tự lưu trữ hoạt động như bộ não thứ hai của bạn, cung cấp khả năng tìm kiếm web và tài liệu, tự động hóa và nghiên cứu chuyên sâu."
+published: 2025-09-07
+tags: ['open-source', 'self-host', 'ai', 'llm', 'automation', 'docker', 'python', 'privacy']
+category: Self-hosted
+author: minhpt
+---
+
+# khoj-ai/khoj - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/khoj-ai/khoj](https://github.com/khoj-ai/khoj)
+- **Sao:** 30783
+
+## 2. Mô Tả Dự Án
+Khoj AI là một trợ lý AI mã nguồn mở, tự lưu trữ được thiết kế để hoạt động như "bộ não thứ hai" của bạn. Nó cho phép người dùng truy vấn thông tin từ web hoặc tài liệu cá nhân của họ, xây dựng các tác nhân AI tùy chỉnh, lên lịch tự động hóa và thực hiện nghiên cứu chuyên sâu. Khoj hỗ trợ tích hợp với nhiều LLM cục bộ và trực tuyến, bao gồm GPT, Claude, Gemini, Llama, Qwen và Mistral, khiến nó trở thành giải pháp thay thế linh hoạt và tập trung vào quyền riêng tư cho các công cụ AI thương mại.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Khoj AI là giải pháp thay thế mạnh mẽ cho một số công cụ AI thương mại và độc quyền, bao gồm:
+- Notion AI
+- Evernote với các tính năng AI
+- ChatGPT Plus (cho các truy vấn được cá nhân hóa, dựa trên tài liệu)
+- Các nền tảng tự động hóa thương mại như Zapier (cho quy trình làm việc dựa trên AI)
+- Các công cụ nghiên cứu và quản lý kiến thức độc quyền
+
+## 4. Chức Năng Chính
+Khoj AI cung cấp một bộ tính năng mạnh mẽ:
+- **Tìm kiếm Tài liệu:** Lập chỉ mục và truy vấn các tài liệu cá nhân của bạn (PDF, markdown, tệp văn bản) để có câu trả lời nhanh chóng.
+- **Tích hợp Tìm kiếm Web:** Tìm nạp và tóm tắt thông tin từ web trực tiếp.
+- **Tác nhân AI Tùy chỉnh:** Xây dựng và triển khai các tác nhân AI phù hợp cho các nhiệm vụ cụ thể.
+- **Lập lịch Tự động hóa:** Thiết lập các tác vụ và quy trình làm việc tự động.
+- **Hỗ trợ Đa LLM:** Sử dụng nhiều LLM khác nhau, cả cục bộ và đám mây, đảm bảo tính linh hoạt và quyền riêng tư.
+- **Triển khai Tự lưu trữ:** Toàn quyền kiểm soát dữ liệu và cơ sở hạ tầng của bạn.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Tập trung vào Quyền riêng tư:** Bản chất tự lưu trữ đảm bảo dữ liệu của bạn vẫn được riêng tư.
+- **Hỗ trợ LLM Linh hoạt:** Tương thích với nhiều mô hình AI, cả mã nguồn mở và độc quyền.
+- **Tùy chỉnh:** Có thể thích ứng cao cho sử dụng cá nhân hoặc tổ chức.
+- **Tiết kiệm Chi phí:** Miễn phí sử dụng và triển khai, tránh phí đăng ký.
+- **Cộng đồng Tích cực:** Sự hiện diện mạnh mẽ trên GitHub với phát triển và hỗ trợ liên tục.
+
+**Nhược điểm:**
+- **Rào cản Kỹ thuật:** Yêu cầu một số kiến thức kỹ thuật để thiết lập và bảo trì.
+- **Tốn nhiều Tài nguyên:** Chạy LLM cục bộ có thể yêu cầu tài nguyên tính toán đáng kể.
+- **Tích hợp Sẵn có Hạn chế:** So với các công cụ thương mại, có thể yêu cầu cấu hình thủ công cho một số quy trình làm việc nhất định.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để tự lưu trữ Khoj AI trên máy chủ Ubuntu:
+
+### Yêu cầu
+- Ubuntu 22.04 LTS trở lên
+- Docker và Docker Compose đã được cài đặt
+- Python 3.8+ (nếu tùy chỉnh ngoài Docker)
+- Ít nhất 8GB RAM (khuyến nghị 16GB+ cho LLM cục bộ)
+
+### Cài đặt Từng bước
+1. **Cập nhật Gói Hệ thống:**
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   ```
+
+2. **Cài đặt Docker và Docker Compose:**
+   ```bash
+   sudo apt install docker.io docker-compose -y
+   sudo systemctl enable docker
+   sudo systemctl start docker
+   ```
+
+3. **Sao chép Kho lưu trữ Khoj:**
+   ```bash
+   git clone https://github.com/khoj-ai/khoj.git
+   cd khoj
+   ```
+
+4. **Cấu hình Biến Môi trường:**
+   Tạo tệp `.env` trong thư mục gốc của dự án và đặt các biến cần thiết (ví dụ: khóa API cho LLM, đường dẫn lưu trữ):
+   ```bash
+   cp .env.example .env
+   nano .env
+   ```
+
+5. **Xây dựng và Khởi động với Docker Compose:**
+   ```bash
+   docker-compose up -d
+   ```
+
+6. **Truy cập Khoj AI:**
+   Mở trình duyệt và điều hướng đến `http://your-server-ip:8000` để truy cập giao diện Khoj.
+
+7. **Tùy chọn: Thiết lập Reverse Proxy (cho sản xuất):**
+   Sử dụng Nginx hoặc Traefik để proxy yêu cầu và kích hoạt HTTPS.
+
+Đối với các cấu hình nâng cao, như tích hợp LLM cụ thể hoặc thiết lập tự động hóa, hãy tham khảo [tài liệu chính thức](https://github.com/khoj-ai/khoj).

--- a/src/content/posts/Self-host-knadh-listmonk-vi.md
+++ b/src/content/posts/Self-host-knadh-listmonk-vi.md
@@ -1,0 +1,114 @@
+---
+lang: vi
+title: "knadh/listmonk: Giải Pháp Quản Lý Bản Tin Tự Lưu Trữ Tối Ưu"
+description: "Khám phá knadh/listmonk, trình quản lý bản tin hiệu suất cao, tự lưu trữ với bảng điều khiển hiện đại. Giải pháp thay thế hoàn hảo cho Mailchimp và Sendy."
+published: 2025-09-21
+tags: ['open-source', 'self-host', 'newsletter', 'mailing-list', 'golang', 'postgresql', 'docker']
+category: Self-hosted
+author: minhpt
+---
+
+# knadh/listmonk - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/knadh/listmonk](https://github.com/knadh/listmonk)
+- **Sao:** 17652
+
+## 2. Mô Tả Dự Án
+knadh/listmonk là một trình quản lý bản tin và danh sách gửi thư mã nguồn mở mạnh mẽ, được thiết kế cho hiệu suất cao và dễ sử dụng. Được xây dựng dưới dạng ứng dụng nhị phân đơn lẻ, nó cung cấp bảng điều khiển hiện đại, quản lý người đăng ký mạnh mẽ và phân tích chiến dịch toàn diện. Lý tưởng cho các nhà phát triển, nhà tiếp thị và tổ chức muốn kiểm soát hoàn toàn giao tiếp email của họ mà không phụ thuộc vào dịch vụ bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+listmonk là giải pháp thay thế hấp dẫn cho một số giải pháp thương mại và mã nguồn mở phổ biến, bao gồm:
+- Mailchimp
+- Sendy (tự lưu trữ)
+- SendGrid (cho các tính năng bản tin cơ bản)
+- Mailjet
+- ConvertKit (cho các trường hợp sử dụng đơn giản hơn)
+
+## 4. Chức Năng Chính
+Các tính năng chính của listmonk bao gồm:
+- **Quản lý Người đăng ký:** Nhập, phân khúc và quản lý người đăng ký với các thuộc tính tùy chỉnh.
+- **Tạo Chiến dịch:** Thiết kế bản tin đáp ứng bằng trình chỉnh sửa tích hợp hoặc HTML.
+- **Tự động hóa:** Lên lịch chiến dịch và thiết lập email kích hoạt.
+- **Phân tích:** Theo dõi lượt mở, nhấp, trả lại và hủy đăng ký theo thời gian thực.
+- **API & Webhook:** Mở rộng chức năng và tích hợp với các công cụ khác.
+- **Mẫu:** Sử dụng mẫu thiết kế sẵn hoặc tạo mẫu tùy chỉnh.
+- **Nhị phân Đơn lẻ:** Triển khai dễ dàng mà không có phụ thuộc phức tạp.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- **Tiết kiệm Chi phí:** Không có phí đăng ký; chỉ chi phí máy chủ.
+- **Quyền riêng tư & Kiểm soát:** Toàn quyền sở hữu dữ liệu và tùy chỉnh tuân thủ.
+- **Hiệu suất Cao:** Xử lý danh sách lớn và khối lượng gửi cao hiệu quả.
+- **Giao diện Hiện đại:** Bảng điều khiển trực quan cho cả người dùng kỹ thuật và phi kỹ thuật.
+- **Phát triển Tích cực:** Cập nhật thường xuyên và cộng đồng đang phát triển.
+
+**Nhược điểm:**
+- **Yêu cầu Tự lưu trữ:** Cần kỹ năng quản lý máy chủ.
+- **Hỗ trợ Hạn chế:** Phụ thuộc vào diễn đàn cộng đồng thay vì hỗ trợ chuyên dụng.
+- **Tính năng Nâng cao:** Có thể thiếu một số tự động hóa nâng cao so với giải pháp doanh nghiệp.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai listmonk trên máy chủ Ubuntu:
+
+### Yêu cầu
+- Ubuntu 20.04 trở lên
+- Docker và Docker Compose đã được cài đặt
+- PostgreSQL (phiên bản 12 trở lên)
+- Có kiến thức cơ bản về terminal
+
+### Bước 1: Cài đặt Docker và Docker Compose
+```bash
+sudo apt update
+sudo apt install docker.io docker-compose
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+### Bước 2: Sao chép Kho lưu trữ listmonk
+```bash
+git clone https://github.com/knadh/listmonk.git
+cd listmonk
+```
+
+### Bước 3: Thiết lập PostgreSQL
+Tạo cơ sở dữ liệu và người dùng PostgreSQL:
+```bash
+sudo -u postgres psql
+CREATE DATABASE listmonk;
+CREATE USER listmonk WITH PASSWORD 'your_secure_password';
+GRANT ALL PRIVILEGES ON DATABASE listmonk TO listmonk;
+\q
+```
+
+### Bước 4: Cấu hình Biến Môi trường
+Chỉnh sửa tệp `config.toml` để cập nhật cài đặt cơ sở dữ liệu và SMTP:
+```toml
+[app]
+address = "0.0.0.0:9000"
+
+[database]
+host = "localhost"
+port = 5432
+user = "listmonk"
+password = "your_secure_password"
+database = "listmonk"
+```
+
+### Bước 5: Chạy với Docker Compose
+Sử dụng `docker-compose.yml` được cung cấp:
+```bash
+docker-compose up -d
+```
+
+### Bước 6: Truy cập listmonk
+Mở trình duyệt và điều hướng đến `http://your_server_ip:9000`. Thông tin đăng nhập mặc định là:
+- Tên đăng nhập: `listmonk`
+- Mật khẩu: `listmonk`
+
+Thay đổi chúng ngay sau lần đăng nhập đầu tiên.
+
+### Bước 7: Cấu hình SMTP
+Thiết lập máy chủ SMTP của bạn (ví dụ: Amazon SES, SendGrid hoặc Postfix cục bộ) trong bảng quản trị tại Cài đặt > SMTP.
+
+Bạn đã sẵn sàng bắt đầu quản lý bản tin với listmonk! Để biết thêm tùy chỉnh, hãy tham khảo [tài liệu chính thức](https://listmonk.app/docs/).

--- a/src/content/posts/Self-host-louislam-dockge-vi.md
+++ b/src/content/posts/Self-host-louislam-dockge-vi.md
@@ -1,0 +1,98 @@
+---
+lang: vi
+title: "Dockge: Trình Quản Lý Docker Compose Tự Lưu Trữ Hiện Đại - Đánh Giá Hoàn Chỉnh & Hướng Dẫn Thiết Lập"
+description: "Khám phá louislam/dockge, trình quản lý Docker Compose tự lưu trữ phản ứng và thân thiện với người dùng với hơn 19K sao GitHub. Tìm hiểu cách cài đặt, tính năng và các lựa chọn thay thế."
+published: 2025-09-19
+tags: ['open-source', 'self-host', 'docker', 'docker-compose', 'web-ui', 'devops']
+category: Self-hosted
+author: minhpt
+---
+
+# louislam/dockge - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/louislam/dockge](https://github.com/louislam/dockge)
+- **Sao:** 19225
+
+## 2. Mô Tả Dự Án
+Dockge là một giao diện web thanh lịch, phản ứng được thiết kế để đơn giản hóa việc quản lý các stack Docker Compose. Không giống như các phương pháp dựa trên CLI truyền thống, Dockge cung cấp một môi trường trực quan, nơi người dùng có thể chỉnh sửa, triển khai và giám sát các tệp `docker-compose.yaml` của họ với cập nhật thời gian thực. Được xây dựng với công nghệ hiện đại bao gồm Express.js và React, nó nhấn mạnh sự dễ sử dụng, giúp việc quản lý stack Docker có thể tiếp cận ngay cả với những người ít quen thuộc với thao tác dòng lệnh.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Dockge là giải pháp thay thế hấp dẫn cho một số công cụ hiện có trong hệ sinh thái Docker:
+- **Portainer**: Trong khi Portainer cung cấp quản lý container rộng hơn, Dockge tập trung cụ thể vào các stack Compose với giao diện phản ứng, tinh gọn hơn.
+- **Docker Compose CLI**: Thay thế việc chỉnh sửa thủ công và thực thi lệnh bằng phương pháp dựa trên web, tương tác.
+- **Yacht** và **CasaOS**: Cho người dùng tìm kiếm một công cụ quản lý nhẹ, hướng đến stack mà không có chi phí của các nền tảng container đầy đủ.
+
+## 4. Chức Năng Chính
+Các tính năng chính của Dockge bao gồm:
+- **Giao diện Web Phản ứng**: Cập nhật thời gian thực và giao diện hiện đại, đáp ứng.
+- **Quản lý Tệp Compose**: Chỉnh sửa, xác thực và triển khai tệp `docker-compose.yaml` trực tiếp qua trình duyệt.
+- **Triển khai Stack**: Triển khai và quản lý stack Docker chỉ với một cú nhấp chuột.
+- **Xem Nhật ký**: Trình xem nhật ký tích hợp để giám sát đầu ra container.
+- **Biến Môi trường**: Quản lý dễ dàng các biến môi trường trong giao diện.
+- **Sao lưu và Phục hồi**: Xuất và nhập cấu hình stack để sao lưu hoặc di chuyển.
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Giao diện thân thiện giúp hạ thấp rào cản quản lý Docker Compose.
+- Phản ứng thời gian thực nâng cao trải nghiệm người dùng.
+- Nhẹ và tập trung duy nhất vào các stack Compose, tránh phình to tính năng.
+- Phát triển tích cực và hỗ trợ cộng đồng mạnh mẽ với hơn 19K sao.
+
+**Nhược điểm:**
+- Thiếu các tính năng quản lý container rộng hơn có trong các công cụ như Portainer.
+- Hiện đang trong quá trình phát triển tích cực, do đó thỉnh thoảng có thể xảy ra lỗi.
+- Yêu cầu Docker và Docker Compose được cài đặt sẵn, có thể là rào cản cho người mới bắt đầu.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+Thực hiện theo các bước sau để triển khai Dockge trên máy chủ Ubuntu (các bản phân phối Linux khác tương tự).
+
+### Yêu cầu:
+- Máy chủ chạy Ubuntu 20.04 trở lên.
+- Docker và Docker Compose đã được cài đặt. Nếu chưa cài đặt, chạy:
+  ```bash
+  sudo apt update && sudo apt install docker.io docker-compose -y
+  ```
+- Đảm bảo dịch vụ Docker đang chạy: `sudo systemctl start docker && sudo systemctl enable docker`.
+
+### Các bước Cài đặt:
+1. **Tạo thư mục cho Dockge:**
+   ```bash
+   mkdir -p /opt/dockge
+   cd /opt/dockge
+   ```
+
+2. **Tạo tệp `docker-compose.yaml`:**
+   ```bash
+   nano docker-compose.yaml
+   ```
+   Dán cấu hình sau:
+   ```yaml
+   version: "3.8"
+   services:
+     dockge:
+       image: louislam/dockge:latest
+       restart: unless-stopped
+       ports:
+         - 5001:5001
+       volumes:
+         - /var/run/docker.sock:/var/run/docker.sock
+         - ./data:/app/data
+         - /opt/dockge/stacks:/opt/stacks
+       environment:
+         - DOCKGE_STACKS_DIR=/opt/stacks
+   ```
+
+3. **Triển khai Stack:**
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Truy cập Dockge:**
+   Mở trình duyệt và điều hướng đến `http://your-server-ip:5001`. Bạn sẽ thấy giao diện Dockge sẵn sàng quản lý các stack Docker Compose của mình.
+
+### Lưu ý Bổ sung:
+- Để quản lý các stack hiện có, đảm bảo chúng nằm trong thư mục được chỉ định trong `DOCKGE_STACKS_DIR` (ở đây là `/opt/dockge/stacks`).
+- Để bảo mật, hãy cân nhắc thiết lập reverse proxy (ví dụ: Nginx) với SSL.
+
+Tận hưởng việc quản lý Docker Compose tinh gọn với Dockge!

--- a/src/content/posts/Self-host-louislam-uptime-kuma-vi.md
+++ b/src/content/posts/Self-host-louislam-uptime-kuma-vi.md
@@ -1,0 +1,161 @@
+---
+lang: vi
+title: "Uptime Kuma: Giải Pháp Giám Sát Tự Lưu Trữ Tối Ưu"
+description: "Khám phá Uptime Kuma, công cụ giám sát mã nguồn mở mạnh mẽ với hơn 73k sao GitHub. Tìm hiểu cách tự lưu trữ và thay thế các giải pháp thương mại."
+published: 2025-08-28
+tags: ['open-source', 'self-host', 'monitoring', 'docker', 'nodejs', 'uptime']
+category: Self-hosted
+author: minhpt
+---
+
+# louislam/uptime-kuma - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/louislam/uptime-kuma](https://github.com/louislam/uptime-kuma)
+- **Sao:** 73635
+
+## 2. Mô Tả Dự Án
+
+Uptime Kuma là một công cụ giám sát thanh lịch, tự lưu trữ được thiết kế để theo dõi thời gian hoạt động và hiệu suất của các trang web, ứng dụng và dịch vụ của bạn. Với giao diện web hiện đại và bộ tính năng toàn diện, nó cung cấp giám sát thời gian thực, cảnh báo và trang trạng thái mà không cần đăng ký thương mại đắt đỏ. Được xây dựng với sự đơn giản và mạnh mẽ trong tâm trí, nó đã trở thành giải pháp hàng đầu cho các nhà phát triển và quản trị viên hệ thống muốn kiểm soát hoàn toàn cơ sở hạ tầng giám sát của họ.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Uptime Kuma là giải pháp thay thế hấp dẫn cho một số giải pháp giám sát phổ biến:
+
+- **UptimeRobot** (SaaS thương mại)
+- **StatusCake** (SaaS thương mại)
+- **Pingdom** (SaaS thương mại)
+- **Nagios** (Mã nguồn mở nhưng phức tạp)
+- **Zabbix** (Giám sát doanh nghiệp)
+- **Datadog Synthetics** (Tính năng thương mại)
+
+## 4. Chức Năng Chính
+
+Uptime Kuma cung cấp một bộ khả năng giám sát mạnh mẽ:
+
+- **Giám sát HTTP(s):** Kiểm tra khả năng truy cập trang web với khoảng thời gian tùy chỉnh
+- **Giám sát Cổng TCP:** Xác minh tính khả dụng của dịch vụ trên các cổng cụ thể
+- **Giám sát Ping:** Kiểm tra tính khả dụng ở cấp độ mạng
+- **Giám sát DNS:** Xác thực độ phân giải bản ghi DNS và thời gian phản hồi
+- **Giám sát Push:** Nhận tín hiệu heartbeat từ các ứng dụng của bạn
+- **Giám sát Đa Vùng:** Triển khai giám sát từ các vị trí địa lý khác nhau
+- **Trang Trạng thái Thời gian thực:** Trang trạng thái công khai với lịch sử sự cố
+- **Hỗ trợ Đa Thông báo:** Cảnh báo qua Telegram, Discord, Slack, Email, Webhook và hơn thế nữa
+- **Giám sát Chứng chỉ:** Cảnh báo hết hạn chứng chỉ SSL/TLS
+- **Theo dõi Thời gian Phản hồi:** Số liệu hiệu suất và dữ liệu lịch sử
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Hoàn toàn miễn phí và mã nguồn mở
+- Giao diện web hiện đại, đáp ứng
+- Dễ dàng thiết lập và cấu hình
+- Nhiều tùy chọn thông báo
+- Nhẹ và tiết kiệm tài nguyên
+- Cộng đồng tích cực và cập nhật thường xuyên
+- Không phụ thuộc vào dịch vụ bên thứ ba
+- Hỗ trợ nhiều giao thức giám sát
+
+**Nhược điểm:**
+- Yêu cầu cơ sở hạ tầng tự lưu trữ
+- Thiếu các tính năng cấp doanh nghiệp của các lựa chọn thương mại
+- Không có giám sát phân tán tích hợp (yêu cầu thiết lập thủ công)
+- Lưu trữ dữ liệu lịch sử hạn chế so với dịch vụ trả phí
+- Chỉ hỗ trợ cộng đồng (không có SLA chính thức)
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+
+- Docker và Docker Compose đã được cài đặt
+- Khuyến nghị 1GB+ RAM
+- Tên miền (tùy chọn cho SSL)
+
+### Cài đặt Từng bước
+
+**1. Cập nhật Gói Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+**2. Cài đặt Docker và Docker Compose**
+```bash
+# Cài đặt Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Cài đặt Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+**3. Tạo Tệp Docker Compose**
+```bash
+mkdir uptime-kuma
+cd uptime-kuma
+nano docker-compose.yml
+```
+
+**4. Thêm nội dung sau:**
+```yaml
+version: '3.8'
+
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    container_name: uptime-kuma
+    volumes:
+      - ./data:/app/data
+    ports:
+      - "3001:3001"
+    restart: unless-stopped
+```
+
+**5. Khởi động Uptime Kuma**
+```bash
+docker-compose up -d
+```
+
+**6. Truy cập Giao diện Web**
+Mở trình duyệt và điều hướng đến:
+```
+http://your-server-ip:3001
+```
+
+**7. Thiết lập Ban đầu**
+- Tạo tài khoản quản trị
+- Cấu hình giám sát đầu tiên của bạn
+- Thiết lập kênh thông báo
+- Tùy chỉnh trang trạng thái của bạn
+
+**8. (Tùy chọn) Reverse Proxy với Nginx**
+```bash
+sudo apt install nginx -y
+sudo nano /etc/nginx/sites-available/uptime-kuma
+```
+
+Thêm cấu hình Nginx:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Kích hoạt site:
+```bash
+sudo ln -s /etc/nginx/sites-available/uptime-kuma /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Phiên bản Uptime Kuma của bạn hiện đã sẵn sàng giám sát các dịch vụ của bạn với khả năng chuyên nghiệp!

--- a/src/content/posts/Self-host-mastodon-mastodon-vi.md
+++ b/src/content/posts/Self-host-mastodon-mastodon-vi.md
@@ -1,0 +1,162 @@
+---
+lang: vi
+title: "Mastodon: Hướng Dẫn Tối Ưu Cho Mạng Xã Hội Phi Tập Trung Tự Lưu Trữ"
+description: "Khám phá Mastodon, nền tảng vi blog mã nguồn mở, tự lưu trữ cung cấp giải pháp thay thế phi tập trung cho các mạng xã hội chính thống."
+published: 2025-08-30
+tags: ['open-source', 'self-host', 'ruby-on-rails', 'decentralized', 'microblogging', 'fediverse']
+category: Self-hosted
+author: minhpt
+---
+
+# mastodon/mastodon - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/mastodon/mastodon](https://github.com/mastodon/mastodon)
+- **Sao:** 48891
+
+## 2. Mô Tả Dự Án
+Mastodon là một nền tảng vi blog mã nguồn mở, tự lưu trữ, là một phần của mạng Fediverse phi tập trung. Không giống như các nền tảng mạng xã hội tập trung, Mastodon cho phép người dùng tham gia hoặc tạo các cộng đồng độc lập (instance) có thể tương tác với nhau. Nó cung cấp trải nghiệm giống Twitter với các kiểm soát quyền riêng tư được nâng cao, kiểm duyệt cộng đồng và không có thao túng dòng thời gian bằng thuật toán.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Mastodon là giải pháp thay thế phi tập trung cho:
+- Twitter/X
+- Facebook (cho các khía cạnh vi blog)
+- Các nền tảng vi blog thương mại
+- Các dịch vụ mạng xã hội tập trung
+
+## 4. Chức Năng Chính
+- **Mạng Phi tập trung:** Hoạt động trên giao thức ActivityPub để liên kết
+- **Khả năng Tự lưu trữ:** Kiểm soát hoàn toàn instance của bạn
+- **Kiểm duyệt Cộng đồng:** Chính sách nội dung và công cụ kiểm duyệt ở cấp instance
+- **Tính năng Quyền riêng tư:** Cảnh báo nội dung, bài đăng riêng tư và tùy chọn hiển thị hạn chế
+- **Không Thuật toán:** Dòng thời gian theo thứ tự thời gian không bị thao túng
+- **Hỗ trợ Đa Phương tiện:** Hình ảnh, video, âm thanh và bình chọn
+- **Khả năng Tiếp cận:** Giao diện tuân thủ WCAG 2.1
+- **Hỗ trợ API:** REST API cho nhà phát triển
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Toàn quyền sở hữu dữ liệu và kiểm soát quyền riêng tư
+- Trải nghiệm không quảng cáo
+- Quy tắc và chính sách instance có thể tùy chỉnh
+- Công cụ kiểm duyệt cộng đồng mạnh mẽ
+- Có thể tương tác với các nền tảng Fediverse khác
+- Phát triển mã nguồn mở, minh bạch
+
+**Nhược điểm:**
+- Yêu cầu kiến thức kỹ thuật để tự lưu trữ
+- Cơ sở người dùng nhỏ hơn so với các nền tảng chính thống
+- Trách nhiệm bảo trì instance
+- Phân mảnh tiềm ẩn giữa các instance
+- Đường cong học tập cho người dùng mới
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+
+- Tối thiểu 2GB RAM (khuyến nghị 4GB)
+- Docker và Docker Compose
+- Tên miền đã cấu hình DNS
+
+### Cài đặt Từng bước
+
+1. **Cập nhật Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+2. **Cài đặt Docker và Docker Compose**
+```bash
+sudo apt install docker.io docker-compose
+sudo systemctl enable --now docker
+```
+
+3. **Tạo Thư mục Mastodon**
+```bash
+mkdir mastodon && cd mastodon
+```
+
+4. **Tải Tệp Docker Compose**
+```bash
+curl -L https://raw.githubusercontent.com/mastodon/mastodon/main/docker-compose.yml -O
+```
+
+5. **Cấu hình Môi trường**
+```bash
+cp .env.production.sample .env.production
+# Chỉnh sửa tệp .env.production với tên miền và khóa bí mật của bạn
+nano .env.production
+```
+
+6. **Tạo Khóa Bí mật**
+```bash
+docker-compose run --rm web bundle exec rake mastodon:webpush:generate_vapid_key
+docker-compose run --rm web rake secret
+# Thêm khóa bí mật đã tạo vào tệp .env của bạn
+```
+
+7. **Xây dựng và Khởi động Container**
+```bash
+docker-compose build
+docker-compose up -d
+```
+
+8. **Chạy Thiết lập Cơ sở dữ liệu**
+```bash
+docker-compose run --rm web rails db:migrate
+docker-compose run --rm web rails assets:precompile
+```
+
+9. **Tạo Người dùng Quản trị**
+```bash
+docker-compose run --rm web rails mastodon:setup
+```
+
+10. **Cấu hình Reverse Proxy (Nginx)**
+```bash
+sudo apt install nginx
+sudo nano /etc/nginx/sites-available/mastodon
+```
+
+Thêm cấu hình Nginx:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+    
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+11. **Kích hoạt SSL với Let's Encrypt**
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d your-domain.com
+```
+
+12. **Khởi động lại Dịch vụ**
+```bash
+docker-compose restart
+sudo systemctl restart nginx
+```
+
+Phiên bản Mastodon của bạn hiện có thể truy cập được tại tên miền của bạn! Hãy nhớ thường xuyên cập nhật instance và giám sát tài nguyên máy chủ.
+
+### Lệnh Bảo trì
+```bash
+# Cập nhật Mastodon
+docker-compose pull
+docker-compose build
+docker-compose run --rm web rails db:migrate
+docker-compose run --rm web rails assets:precompile
+docker-compose restart
+
+# Sao lưu cơ sở dữ liệu
+docker-compose exec db pg_dump -U postgres mastodon_production > backup.sql
+```
+
+Để biết cấu hình chi tiết hơn và khắc phục sự cố, hãy tham khảo tài liệu Mastodon chính thức tại [https://docs.joinmastodon.org](https://docs.joinmastodon.org).

--- a/src/content/posts/Self-host-mattermost-community-focalboard-vi.md
+++ b/src/content/posts/Self-host-mattermost-community-focalboard-vi.md
@@ -1,0 +1,132 @@
+---
+lang: vi
+title: "Đánh Giá Focalboard: Giải Pháp Thay Thế Mã Nguồn Mở Tối Ưu Cho Trello và Notion"
+description: "Khám phá Focalboard, công cụ quản lý dự án tự lưu trữ với hơn 24K sao GitHub. Tìm hiểu cách nó so sánh với Trello, Notion và Asana, và cách triển khai."
+published: 2025-09-13
+tags: ['open-source', 'self-host', 'project-management', 'docker', 'react', 'typescript']
+category: Self-hosted
+author: minhpt
+---
+
+# mattermost-community/focalboard - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/mattermost-community/focalboard](https://github.com/mattermost-community/focalboard)
+- **Sao:** 24832
+
+## 2. Mô Tả Dự Án
+
+Focalboard là một công cụ quản lý dự án mã nguồn mở, tự lưu trữ được thiết kế như một giải pháp thay thế linh hoạt cho các nền tảng phổ biến như Trello, Notion và Asana. Được xây dựng bởi cộng đồng Mattermost, nó cung cấp bảng kanban, quản lý tác vụ và không gian làm việc cộng tác, tất cả trong khi cho người dùng toàn quyền kiểm soát dữ liệu thông qua khả năng tự lưu trữ. Cho dù sử dụng cá nhân hay cộng tác nhóm, Focalboard kết hợp tính linh hoạt với quyền riêng tư.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Focalboard là giải pháp thay thế mạnh mẽ cho một số công cụ quản lý dự án và năng suất nổi tiếng, bao gồm:
+
+- **Trello:** Cho theo dõi tác vụ và dự án kiểu kanban.
+- **Notion:** Cho ghi chú, cơ sở dữ liệu và không gian làm việc cộng tác.
+- **Asana:** Cho quản lý tác vụ nhóm và lập kế hoạch dự án.
+- **Monday.com:** Cho bảng công việc và quy trình làm việc có thể tùy chỉnh.
+
+## 4. Chức Năng Chính
+
+Bộ tính năng của Focalboard toàn diện và thân thiện với người dùng, tập trung vào:
+
+- **Bảng Kanban:** Tạo, tổ chức và theo dõi tác vụ bằng các cột và thẻ có thể tùy chỉnh.
+- **Chế độ Xem:** Chuyển đổi giữa chế độ xem bảng, bảng kanban, thư viện và lịch để hiển thị dự án linh hoạt.
+- **Cộng tác:** Cập nhật thời gian thực, bình luận và đề cập để phối hợp nhóm.
+- **Mẫu:** Mẫu dựng sẵn cho các quy trình làm việc phổ biến như lộ trình sản phẩm, lập kế hoạch sprint và quản lý tác vụ cá nhân.
+- **Tự lưu trữ:** Toàn quyền sở hữu và riêng tư dữ liệu, với tùy chọn triển khai tại chỗ hoặc đám mây.
+- **Tích hợp:** Tương thích với Mattermost để trò chuyện và cộng tác liền mạch, với tiềm năng tích hợp khác qua API.
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm:
+- **Mã nguồn Mở:** Miễn phí sử dụng, sửa đổi và đóng góp, với sự hậu thuẫn mạnh mẽ từ cộng đồng.
+- **Tự lưu trữ:** Kiểm soát dữ liệu và quyền riêng tư hoàn toàn, lý tưởng cho doanh nghiệp hoặc người dùng có ý thức về quyền riêng tư.
+- **Giàu Tính năng:** Cung cấp nhiều chế độ xem, mẫu và công cụ cộng tác tương đương với các lựa chọn trả phí.
+- **Phát triển Tích cực:** Cập nhật và cải tiến thường xuyên từ cộng đồng Mattermost.
+
+### Nhược điểm:
+- **Độ phức tạp khi Tự lưu trữ:** Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì so với các giải pháp SaaS.
+- **Tích hợp Gốc Hạn chế:** Mặc dù có thể mở rộng, có thể không có nhiều tích hợp sẵn như các công cụ thương mại.
+- **Đường cong Học tập:** Người dùng mới có thể cần thời gian để khám phá tất cả các tính năng và tùy chọn tùy chỉnh.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Thực hiện theo các bước sau để triển khai Focalboard trên máy chủ Ubuntu (22.04 LTS trở lên). Hướng dẫn này giả định bạn có quyền sudo và kiến thức dòng lệnh cơ bản.
+
+### Yêu cầu:
+- Máy chủ Ubuntu (22.04+)
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến máy chủ của bạn (tùy chọn cho HTTPS)
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker && sudo systemctl start docker
+```
+
+### Bước 2: Tạo Tệp Docker Compose
+Tạo thư mục cho Focalboard và điều hướng vào đó:
+```bash
+mkdir focalboard && cd focalboard
+```
+
+Tạo tệp `docker-compose.yml`:
+```yaml
+version: '3'
+
+services:
+  focalboard:
+    image: mattermost/focalboard:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - DB_TYPE=sqlite3
+      - DB_CONFIG='./focalboard.db'
+    volumes:
+      - ./data:/opt/focalboard/data
+    restart: unless-stopped
+```
+
+### Bước 3: Triển khai Focalboard
+Chạy lệnh sau để khởi động container:
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 4: Truy cập Focalboard
+Sau khi triển khai, truy cập Focalboard qua IP hoặc tên miền máy chủ của bạn tại cổng 8000 (ví dụ: `http://your-server-ip:8000`). Bạn có thể thiết lập reverse proxy với Nginx và SSL để sử dụng trong sản xuất.
+
+### Bước 5: Tùy chọn - Bảo mật với Nginx và Let's Encrypt
+Cài đặt Nginx và Certbot:
+```bash
+sudo apt install nginx certbot python3-certbot-nginx -y
+```
+
+Tạo tệp cấu hình Nginx cho tên miền của bạn (ví dụ: `/etc/nginx/sites-available/focalboard`):
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Kích hoạt site và lấy chứng chỉ SSL:
+```bash
+sudo ln -s /etc/nginx/sites-available/focalboard /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d your-domain.com
+```
+
+Phiên bản Focalboard của bạn hiện đã hoạt động và được bảo mật bằng HTTPS!
+
+Để biết thêm tùy chỉnh, tùy chọn cơ sở dữ liệu (PostgreSQL/MySQL) và cấu hình nâng cao, hãy tham khảo [tài liệu Focalboard](https://www.focalboard.com/) chính thức.

--- a/src/content/posts/Self-host-mudler-LocalAI-vi.md
+++ b/src/content/posts/Self-host-mudler-LocalAI-vi.md
@@ -1,0 +1,124 @@
+---
+lang: vi
+title: "LocalAI: Giải Pháp Thay Thế Tự Lưu Trữ Tối Ưu Cho OpenAI và Claude"
+description: "Khám phá mudler/LocalAI, nền tảng AI mã nguồn mở, tự lưu trữ chạy trên phần cứng tiêu dùng mà không cần GPU. Đánh giá đầy đủ và hướng dẫn cài đặt."
+published: 2025-09-05
+tags: ['open-source', 'self-host', 'ai', 'machine-learning', 'local-ai', 'docker', 'gguf', 'transformers']
+category: Self-hosted
+author: minhpt
+---
+
+# mudler/LocalAI - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/mudler/LocalAI](https://github.com/mudler/LocalAI)
+- **Sao:** 34793
+
+## 2. Mô Tả Dự Án
+
+LocalAI là một dự án mã nguồn mở đột phá, phục vụ như giải pháp thay thế miễn phí, tự lưu trữ cho các dịch vụ AI thương mại như OpenAI và Claude của Anthropic. Được thiết kế với quyền riêng tư và khả năng tiếp cận trong tâm trí, nó cho phép người dùng chạy các mô hình AI tinh vi cục bộ trên phần cứng cấp tiêu dùng mà không cần GPU đắt tiền. Nền tảng hỗ trợ nhiều kiến trúc mô hình bao gồm gguf, transformers và diffusers, cung cấp các khả năng từ tạo văn bản đến xử lý âm thanh/video và thậm chí nhân bản giọng nói.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+LocalAI là giải pháp thay thế tương thích ngay cho một số dịch vụ AI thương mại phổ biến:
+
+- Các mô hình GPT của OpenAI (ChatGPT API)
+- API Claude của Anthropic
+- Dịch vụ tạo hình ảnh thương mại (các lựa chọn thay thế Midjourney, DALL-E)
+- Dịch vụ tổng hợp và nhân bản giọng nói
+- Các nền tảng suy luận AI độc quyền khác nhau
+
+## 4. Chức Năng Chính
+
+LocalAI tự hào có một bộ tính năng ấn tượng:
+
+- **Tạo Văn bản**: Tương thích đầy đủ với API OpenAI cho chat và hoàn thành
+- **Hỗ trợ Đa Phương thức**: Xử lý hình ảnh, âm thanh và tạo video
+- **Nhân bản Giọng nói**: Khả năng tổng hợp và nhân bản giọng nói nâng cao
+- **Suy luận Phân tán**: Hỗ trợ mô hình tính toán P2P và phân tán
+- **Linh hoạt Mô hình**: Tương thích với gguf, transformers, diffusers và nhiều kiến trúc mô hình
+- **Không phụ thuộc Phần cứng**: Chạy hiệu quả trên hệ thống chỉ có CPU
+- **Quyền riêng tư Trước hết**: Tất cả xử lý diễn ra cục bộ mà không có cuộc gọi API bên ngoài
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- Quyền riêng tư và chủ quyền dữ liệu hoàn toàn
+- Không có chi phí API liên tục hoặc giới hạn sử dụng
+- Hỗ trợ nhiều định dạng và kiến trúc mô hình
+- Hoạt động trên phần cứng tiêu dùng không cần GPU
+- Phát triển mã nguồn mở và do cộng đồng thúc đẩy
+- Thay thế tương thích cho OpenAI API
+
+**Nhược điểm:**
+- Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì
+- Hiệu suất có thể chậm hơn các lựa chọn đám mây trên phần cứng cấp thấp
+- Quản lý và lưu trữ mô hình có thể phức tạp
+- Giới hạn bởi khả năng phần cứng cho các mô hình lớn hơn
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+ (hoặc bản phân phối Linux tương tự)
+- Docker và Docker Compose đã được cài đặt
+- Tối thiểu 8GB RAM (khuyến nghị 16GB cho mô hình lớn hơn)
+- 20GB+ dung lượng đĩa trống cho mô hình
+
+### Cài đặt Từng bước
+
+1. **Cập nhật Gói Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+2. **Cài đặt Docker**
+```bash
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+3. **Tạo Thư mục LocalAI**
+```bash
+mkdir localai && cd localai
+```
+
+4. **Tạo Tệp Docker Compose**
+```bash
+cat > docker-compose.yml << EOF
+version: '3.8'
+services:
+  localai:
+    image: quay.io/go-skynet/local-ai:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./models:/models
+    environment:
+      - MODELS_PATH=/models
+    restart: unless-stopped
+EOF
+```
+
+5. **Tải Mô hình Mẫu**
+```bash
+mkdir models
+wget -O models/ggml-gpt4all-j.bin https://gpt4all.io/models/ggml-gpt4all-j.bin
+```
+
+6. **Khởi động LocalAI**
+```bash
+sudo docker-compose up -d
+```
+
+7. **Xác minh Cài đặt**
+```bash
+curl http://localhost:8080/v1/models
+```
+
+### Cấu hình và Sử dụng
+
+Sau khi cài đặt, bạn có thể sử dụng LocalAI với bất kỳ ứng dụng khách tương thích OpenAI nào bằng cách đặt URL cơ sở thành `http://your-server-ip:8080`. Nền tảng sẽ tự động tải xuống và quản lý các mô hình khi cần, hoặc bạn có thể đặt thủ công các tệp mô hình trong thư mục `./models`.
+
+Để cấu hình nâng cao, hãy tạo tệp `config.yaml` trong thư mục models của bạn để chỉ định cài đặt và tùy chọn mô hình.

--- a/src/content/posts/Self-host-n8n-io-n8n-vi.md
+++ b/src/content/posts/Self-host-n8n-io-n8n-vi.md
@@ -1,0 +1,155 @@
+---
+lang: vi
+title: "n8n-io/n8n: Nền Tảng Tự Động Hóa Quy Trình Làm Việc Fair-Code Tối Ưu"
+description: "Khám phá n8n-io/n8n, công cụ tự động hóa quy trình làm việc fair-code mạnh mẽ với khả năng AI gốc, hơn 400 tích hợp và tùy chọn tự lưu trữ."
+published: 2025-08-25
+tags: ['open-source', 'self-host', 'workflow-automation', 'nodejs', 'docker', 'ai-integrations']
+category: Self-hosted
+author: minhpt
+---
+
+# n8n-io/n8n - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/n8n-io/n8n](https://github.com/n8n-io/n8n)
+- **Sao:** 132071
+
+## 2. Mô Tả Dự Án
+n8n-io/n8n là một nền tảng tự động hóa quy trình làm việc được cấp phép fair-code, kết hợp xây dựng trực quan với khả năng mã tùy chỉnh. Nó cung cấp tích hợp AI gốc, hỗ trợ hơn 400 dịch vụ bên thứ ba và cung cấp các tùy chọn triển khai linh hoạt bao gồm tự lưu trữ và đám mây. Được thiết kế cho các nhà phát triển và người dùng kỹ thuật, n8n cho phép tạo các tự động hóa phức tạp thông qua giao diện dựa trên nút trực quan trong khi vẫn duy trì khả năng mở rộng chức năng thông qua JavaScript.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+n8n có thể là giải pháp thay thế cho một số nền tảng tự động hóa và tích hợp phổ biến bao gồm:
+- Zapier
+- Make (trước đây là Integromat)
+- Microsoft Power Automate
+- Tray.io
+- Workato
+- IFTTT (cho các quy trình làm việc phức tạp hơn)
+
+## 4. Chức Năng Chính
+- **Trình xây dựng Quy trình làm việc Trực quan**: Giao diện kéo và thả để tạo quy trình làm việc tự động hóa
+- **400+ Tích hợp Gốc**: Kết nối dựng sẵn đến các dịch vụ và API phổ biến
+- **Nút Mã Tùy chỉnh**: Hỗ trợ JavaScript cho logic và biến đổi tùy chỉnh
+- **Khả năng AI**: Tích hợp gốc với các dịch vụ AI cho tự động hóa thông minh
+- **Tùy chọn Tự lưu trữ**: Kiểm soát hoàn toàn môi trường triển khai của bạn
+- **Hỗ trợ Webhook**: Khả năng kích hoạt sự kiện thời gian thực
+- **Xử lý Lỗi**: Cơ chế tích hợp để gỡ lỗi và phục hồi quy trình làm việc
+- **Lịch sử Thực thi**: Nhật ký chi tiết của các lần chạy quy trình làm việc và số liệu hiệu suất
+
+## 5. Ưu và Nhược Điểm
+**Ưu điểm:**
+- Mã nguồn mở với mô hình cấp phép fair-code
+- Hệ sinh thái tích hợp phong phú
+- Khả năng mã tùy chỉnh mạnh mẽ
+- Tùy chọn triển khai linh hoạt (tự lưu trữ hoặc đám mây)
+- Hỗ trợ cộng đồng mạnh mẽ và phát triển tích cực
+- Khả năng tích hợp AI gốc
+- Không bị khóa nhà cung cấp cho các instance tự lưu trữ
+
+**Nhược điểm:**
+- Đường cong học tập dốc hơn so với các công cụ tự động hóa đơn giản hơn
+- Tự lưu trữ yêu cầu chuyên môn kỹ thuật
+- Các tính năng doanh nghiệp có thể yêu cầu cấp phép trả phí
+- Trải nghiệm di động hạn chế so với một số đối thủ cạnh tranh
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+ (hoặc bản phân phối Linux tương tự)
+- Docker và Docker Compose đã được cài đặt
+- Tối thiểu 2GB RAM (khuyến nghị 4GB cho sản xuất)
+- Tên miền đã cấu hình DNS (để truy cập web)
+
+### Cài đặt Từng bước
+
+1. **Cập nhật Gói Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+2. **Cài đặt Docker và Docker Compose**
+```bash
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+3. **Tạo Thư mục n8n**
+```bash
+mkdir ~/n8n && cd ~/n8n
+```
+
+4. **Tạo Tệp Docker Compose**
+Tạo `docker-compose.yml` với nội dung sau:
+
+```yaml
+version: '3.8'
+services:
+  n8n:
+    image: n8nio/n8n
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_HOST=your-domain.com
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=https
+      - NODE_ENV=production
+    volumes:
+      - n8n_data:/home/node/.n8n
+volumes:
+  n8n_data:
+```
+
+5. **Khởi động Dịch vụ n8n**
+```bash
+docker-compose up -d
+```
+
+6. **Cấu hình Reverse Proxy (Tùy chọn nhưng Khuyến nghị)**
+Cài đặt nginx và cấu hình reverse proxy cho SSL:
+
+```bash
+sudo apt install nginx -y
+sudo systemctl enable nginx
+```
+
+Tạo tệp cấu hình nginx tại `/etc/nginx/sites-available/n8n`:
+
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:5678;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Kích hoạt site và khởi động lại nginx:
+```bash
+sudo ln -s /etc/nginx/sites-available/n8n /etc/nginx/sites-enabled/
+sudo systemctl restart nginx
+```
+
+7. **Truy cập n8n**
+Mở trình duyệt và điều hướng đến `https://your-domain.com` (hoặc `http://your-server-ip:5678` nếu không sử dụng reverse proxy)
+
+8. **Thiết lập Ban đầu**
+- Tạo tài khoản người dùng đầu tiên của bạn
+- Cấu hình URL cơ sở trong cài đặt
+- Thiết lập quy trình làm việc đầu tiên của bạn hoặc khám phá mẫu
+
+### Bảo trì
+- Thường xuyên cập nhật n8n bằng cách kéo image Docker mới nhất
+- Giám sát dung lượng đĩa cho volume n8n_data
+- Thiết lập sao lưu định kỳ các cấu hình quy trình làm việc của bạn
+
+Để sử dụng trong sản xuất, hãy cân nhắc các biện pháp bảo mật bổ sung bao gồm:
+- Cài đặt chứng chỉ SSL
+- Cấu hình tường lửa
+- Cập nhật bảo mật thường xuyên
+- Chuyển cơ sở dữ liệu ra ngoài (PostgreSQL) để có hiệu suất tốt hơn

--- a/src/content/posts/Self-host-rustdesk-rustdesk-vi.md
+++ b/src/content/posts/Self-host-rustdesk-rustdesk-vi.md
@@ -1,0 +1,158 @@
+---
+lang: vi
+title: "RustDesk: Giải Pháp Máy Tính Từ Xa Mã Nguồn Mở Tối Ưu Cho Tự Lưu Trữ"
+description: "Khám phá RustDesk, ứng dụng máy tính từ xa mã nguồn mở mạnh mẽ với hơn 96k sao GitHub. Tìm hiểu cách tự lưu trữ nó như một giải pháp thay thế TeamViewer."
+published: 2025-08-26
+tags: ['open-source', 'self-host', 'remote-desktop', 'rust', 'privacy']
+category: Self-hosted
+author: minhpt
+---
+
+# rustdesk/rustdesk - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/rustdesk/rustdesk](https://github.com/rustdesk/rustdesk)
+- **Sao:** 96220
+
+## 2. Mô Tả Dự Án
+
+RustDesk là một ứng dụng máy tính từ xa hiện đại, mã nguồn mở được viết bằng Rust, cung cấp khả năng truy cập từ xa an toàn, đa nền tảng. Được thiết kế với quyền riêng tư và khả năng tự lưu trữ trong tâm trí, nó cung cấp cả tùy chọn máy chủ công cộng và khả năng triển khai máy chủ chuyển tiếp của riêng bạn, mang lại cho người dùng toàn quyền kiểm soát cơ sở hạ tầng máy tính từ xa của họ.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+RustDesk là giải pháp thay thế hấp dẫn cho một số giải pháp máy tính từ xa phổ biến:
+
+- **TeamViewer** - Phần mềm truy cập từ xa thương mại
+- **AnyDesk** - Ứng dụng máy tính từ xa độc quyền
+- **Splashtop** - Công cụ truy cập từ xa doanh nghiệp
+- **Chrome Remote Desktop** - Giải pháp dựa trên trình duyệt của Google
+- **Windows Remote Desktop** - Giải pháp tích hợp của Microsoft
+
+## 4. Chức Năng Chính
+
+RustDesk cung cấp một bộ tính năng toàn diện:
+
+- **Hỗ trợ Đa nền tảng**: Windows, macOS, Linux, Android, iOS
+- **Hiệu suất Cao**: Tối ưu hóa cho độ trễ thấp và tốc độ khung hình cao
+- **Mã hóa Đầu cuối**: Giao tiếp an toàn với TLS 1.3
+- **Truyền Tệp**: Chia sẻ tệp kéo và thả dễ dàng
+- **Trò chuyện Thoại**: Giao tiếp âm thanh tích hợp
+- **Hỗ trợ Nhiều Màn hình**: Truy cập nhiều màn hình liền mạch
+- **Tăng tốc Phần cứng**: Kết xuất tăng tốc GPU
+- **Truy cập ID/Mật khẩu**: Thiết lập kết nối đơn giản
+- **Truy cập Không giám sát**: Khả năng truy cập từ xa vĩnh viễn
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm:
+- **Mã nguồn Mở**: Mã nguồn minh bạch với sự đóng góp của cộng đồng
+- **Tùy chọn Tự lưu trữ**: Kiểm soát hoàn toàn dữ liệu và cơ sở hạ tầng
+- **Tiết kiệm Chi phí**: Miễn phí sử dụng với tùy chọn lưu trữ trả phí
+- **Tập trung vào Quyền riêng tư**: Không thu thập dữ liệu khi tự lưu trữ
+- **Nhẹ**: Tiêu thụ tài nguyên tối thiểu
+- **Phát triển Tích cực**: Cập nhật và cải tiến thường xuyên
+
+### Nhược điểm:
+- **Độ phức tạp Thiết lập**: Tự lưu trữ yêu cầu kiến thức kỹ thuật
+- **Hạn chế Ứng dụng Di động**: Một số tính năng nâng cao kém tối ưu hóa trên di động
+- **Tài liệu**: Có thể toàn diện hơn cho các thiết lập nâng cao
+- **Tính năng Doanh nghiệp**: Thiếu một số công cụ quản lý cấp doanh nghiệp
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04+ (tối thiểu 2GB RAM, khuyến nghị 4GB)
+- Docker và Docker Compose đã được cài đặt
+- Tên miền đã cấu hình DNS (tùy chọn nhưng khuyến nghị)
+- Mở cổng: 21115-21119 (TCP), 21116 (UDP)
+
+### Cài đặt Từng bước
+
+1. **Cập nhật Hệ thống**
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+2. **Cài đặt Docker**
+```bash
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+3. **Tạo Thư mục Triển khai**
+```bash
+mkdir rustdesk-server && cd rustdesk-server
+```
+
+4. **Tạo Tệp Docker Compose**
+```yaml
+version: '3'
+
+networks:
+  rustdesk-net:
+    driver: bridge
+
+services:
+  hbbs:
+    container_name: rustdesk-hbbs
+    ports:
+      - "21115:21115"
+      - "21116:21116"
+      - "21116:21116/udp"
+      - "21118:21118"
+    image: rustdesk/rustdesk-server:latest
+    command: hbbs -r your-domain.com:21117
+    volumes:
+      - ./data:/root
+    networks:
+      - rustdesk-net
+    restart: unless-stopped
+
+  hbbr:
+    container_name: rustdesk-hbbr
+    ports:
+      - "21117:21117"
+      - "21119:21119"
+    image: rustdesk/rustdesk-server:latest
+    command: hbbr
+    volumes:
+      - ./data:/root
+    networks:
+      - rustdesk-net
+    restart: unless-stopped
+```
+
+5. **Thay thế Tên miền**
+Thay thế `your-domain.com` bằng tên miền thực tế hoặc địa chỉ IP máy chủ của bạn.
+
+6. **Khởi động Dịch vụ**
+```bash
+sudo docker-compose up -d
+```
+
+7. **Cấu hình Tường lửa**
+```bash
+sudo ufw allow 21115:21119/tcp
+sudo ufw allow 21116/udp
+```
+
+8. **Xác minh Cài đặt**
+Kiểm tra xem các dịch vụ có đang chạy không:
+```bash
+sudo docker-compose ps
+```
+
+9. **Cấu hình Ứng dụng khách**
+Tải ứng dụng khách RustDesk và cấu hình để sử dụng máy chủ tự lưu trữ của bạn bằng cách nhập địa chỉ máy chủ vào trường máy chủ ID.
+
+### Cấu hình Bổ sung
+
+Để tăng cường bảo mật, hãy cân nhắc:
+- Thiết lập chứng chỉ SSL với Let's Encrypt
+- Cấu hình reverse proxy (Nginx)
+- Thực hiện các quy tắc tường lửa
+- Thiết lập sao lưu định kỳ thư mục dữ liệu
+
+Máy chủ RustDesk tự lưu trữ của bạn hiện đã sẵn sàng! Bạn có thể truy cập nó bằng IP hoặc tên miền máy chủ trong cài đặt ứng dụng khách RustDesk.

--- a/src/content/posts/Self-host-siyuan-note-siyuan-vi.md
+++ b/src/content/posts/Self-host-siyuan-note-siyuan-vi.md
@@ -1,0 +1,139 @@
+---
+lang: vi
+title: "Siyuan Note: Hệ Thống Quản Lý Kiến Thức Mã Nguồn Mở, Tự Lưu Trữ Tối Ưu"
+description: "Khám phá Siyuan Note, phần mềm quản lý kiến thức mã nguồn mở ưu tiên quyền riêng tư, cạnh tranh với các lựa chọn thương mại. Tìm hiểu cách tự lưu trữ trên Linux."
+published: 2025-09-03
+tags: ['open-source', 'self-host', 'typescript', 'golang', 'knowledge-management', 'privacy']
+category: Self-hosted
+author: minhpt
+---
+
+# siyuan-note/siyuan - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/siyuan-note/siyuan](https://github.com/siyuan-note/siyuan)
+- **Sao:** 36779
+
+## 2. Mô Tả Dự Án
+
+Siyuan Note là một phần mềm quản lý kiến thức cá nhân tiên tiến, ưu tiên quyền riêng tư, kết hợp sức mạnh của TypeScript và Golang để mang đến trải nghiệm ghi chú tự lưu trữ liền mạch. Không giống như các giải pháp dựa trên đám mây, Siyuan ưu tiên chủ quyền dữ liệu người dùng bằng cách cho phép lưu trữ cục bộ hoàn toàn và đồng bộ hóa giữa các thiết bị mà không phụ thuộc vào máy chủ bên thứ ba. Hệ thống chỉnh sửa dựa trên khối cho phép tổ chức ý tưởng linh hoạt, đồng thời hỗ trợ tích hợp đa phương tiện, khiến nó trở thành công cụ lý tưởng cho các nhà nghiên cứu, nhà văn và bất kỳ ai muốn quản lý suy nghĩ kỹ thuật số của mình một cách an toàn.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Siyuan Note là giải pháp thay thế mạnh mẽ cho một số công cụ quản lý kiến thức thương mại và mã nguồn mở phổ biến, bao gồm:
+
+- **Notion**: Trong khi Notion cung cấp các tính năng cộng tác phong phú, Siyuan cung cấp chức năng tương tự với quyền riêng tư và khả năng ngoại tuyến được nâng cao.
+- **Evernote**: Cho người dùng tìm kiếm giải pháp ghi chú có thể tùy chỉnh và tự lưu trữ hơn mà không có phí đăng ký.
+- **Obsidian**: Mặc dù Obsidian cũng dựa trên markdown và ưu tiên cục bộ, Siyuan khác biệt với cộng tác thời gian thực và tùy chọn đồng bộ tích hợp.
+- **OneNote**: Lý tưởng cho những người thích phần mềm mã nguồn mở hơn hệ sinh thái của Microsoft.
+
+## 4. Chức Năng Chính
+
+Siyuan Note tự hào có một bộ tính năng toàn diện được thiết kế cho quản lý kiến thức hiệu quả:
+
+- **Chỉnh sửa Dựa trên Khối**: Tổ chức nội dung trong các khối có thể tùy chỉnh, tương tự Notion, cho phép cấu trúc tài liệu động.
+- **Cộng tác Thời gian thực**: Nhiều người dùng có thể chỉnh sửa tài liệu cùng lúc khi lưu trữ trên máy chủ riêng.
+- **Mã hóa Đầu cuối**: Bảo mật ghi chú của bạn bằng mã hóa, đảm bảo chỉ những người dùng được ủy quyền mới có thể truy cập.
+- **Đồng bộ Đa nền tảng**: Đồng bộ hóa ghi chú giữa các thiết bị bằng giải pháp lưu trữ tự lưu trữ hoặc đám mây như WebDAV.
+- **Hỗ trợ Đa Phương tiện**: Nhúng hình ảnh, video, âm thanh và đoạn mã liền mạch vào ghi chú của bạn.
+- **Chế độ xem Đồ thị**: Hình dung kết nối giữa các ghi chú với đồ thị tương tác, giúp khám phá mối quan hệ giữa các ý tưởng.
+- **Hệ thống Mẫu**: Sử dụng mẫu dựng sẵn cho nhật ký, kế hoạch dự án và hơn thế nữa để tăng tốc tạo ghi chú.
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm:
+- **Ưu tiên Quyền riêng tư**: Tất cả dữ liệu được lưu trữ cục bộ hoặc trên máy chủ của riêng bạn, mang lại cho bạn toàn quyền kiểm soát.
+- **Mã nguồn Mở**: Cộng đồng phát triển minh bạch với các bản cập nhật và đóng góp thường xuyên.
+- **Tính năng Mạnh mẽ**: Kết hợp tốt nhất của chỉnh sửa dựa trên khối với các công cụ tổ chức nâng cao.
+- **Linh hoạt Tự lưu trữ**: Triển khai trên cơ sở hạ tầng của riêng bạn, tránh bị khóa nhà cung cấp.
+- **Cộng đồng Tích cực**: Sự hiện diện mạnh mẽ trên GitHub với tài liệu phong phú và hỗ trợ người dùng.
+
+### Nhược điểm:
+- **Đường cong Học tập Dốc**: Người dùng mới có thể cần thời gian để thích nghi với hệ thống dựa trên khối và các tính năng nâng cao.
+- **Độ phức tạp khi Tự lưu trữ**: Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì, đặc biệt là đồng bộ hóa.
+- **Trải nghiệm Di động Hạn chế**: Mặc dù có chức năng, ứng dụng di động không được trau chuốt như một số lựa chọn thương mại.
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+Thực hiện theo các bước sau để tự lưu trữ Siyuan Note trên máy chủ Ubuntu (22.04 LTS trở lên). Hướng dẫn này giả định bạn có quyền sudo và hiểu biết cơ bản về lệnh Linux.
+
+### Yêu cầu:
+- Máy chủ Ubuntu (khuyến nghị 22.04 LTS)
+- Docker và Docker Compose đã được cài đặt
+- Tên miền trỏ đến IP máy chủ của bạn (tùy chọn cho HTTPS)
+
+### Bước 1: Cập nhật Hệ thống và Cài đặt Docker
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install docker.io docker-compose -y
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+### Bước 2: Tạo Thư mục cho Siyuan
+```bash
+mkdir ~/siyuan && cd ~/siyuan
+```
+
+### Bước 3: Tạo Tệp Docker Compose
+Tạo một tệp `docker-compose.yml` với nội dung sau:
+
+```yaml
+version: '3'
+services:
+  siyuan:
+    image: b3log/siyuan:latest
+    container_name: siyuan
+    restart: unless-stopped
+    ports:
+      - "6806:6806"
+    volumes:
+      - ./data:/opt/siyuan/data
+    environment:
+      - TZ=UTC
+```
+
+### Bước 4: Triển khai Siyuan Note
+```bash
+sudo docker-compose up -d
+```
+
+### Bước 5: Truy cập Siyuan Note
+Mở trình duyệt và điều hướng đến `http://your-server-ip:6806`. Bạn sẽ thấy giao diện Siyuan. Để sử dụng trong sản xuất, hãy cân nhắc thiết lập reverse proxy (ví dụ: Nginx) với SSL để truy cập an toàn.
+
+### Bước 6: (Tùy chọn) Thiết lập Reverse Proxy Nginx
+Cài đặt Nginx và tạo tệp cấu hình:
+```bash
+sudo apt install nginx -y
+sudo nano /etc/nginx/sites-available/siyuan
+```
+
+Thêm cấu hình sau, thay thế `your-domain.com` bằng tên miền thực tế của bạn:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:6806;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Kích hoạt site và khởi động lại Nginx:
+```bash
+sudo ln -s /etc/nginx/sites-available/siyuan /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl restart nginx
+```
+
+Để có HTTPS, cài đặt Certbot và lấy chứng chỉ SSL:
+```bash
+sudo apt install certbot python3-certbot-nginx -y
+sudo certbot --nginx -d your-domain.com
+```
+
+Bạn đã có Siyuan Note chạy an toàn trên máy chủ của riêng mình!

--- a/src/content/posts/Self-host-usememos-memos-vi.md
+++ b/src/content/posts/Self-host-usememos-memos-vi.md
@@ -1,0 +1,138 @@
+---
+lang: vi
+title: "usememos/memos: Nền Tảng Quản Lý Kiến Thức Tự Lưu Trữ Tối Ưu"
+description: "Đánh giá chi tiết về usememos/memos, nền tảng ghi chú mã nguồn mở, tự lưu trữ với hơn 43k sao GitHub. Tính năng, ưu/nhược điểm và hướng dẫn cài đặt."
+published: 2025-09-02
+tags: ['open-source', 'self-host', 'knowledge-management', 'note-taking', 'privacy', 'docker', 'sqlite']
+category: Self-hosted
+author: minhpt
+---
+
+# usememos/memos - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/usememos/memos](https://github.com/usememos/memos)
+- **Sao:** 43792
+
+## 2. Mô Tả Dự Án
+
+usememos/memos là một nền tảng quản lý kiến thức và ghi chú hiện đại, mã nguồn mở được thiết kế cho người dùng và tổ chức ưu tiên quyền riêng tư và quyền sở hữu dữ liệu. Nó cung cấp giao diện sạch sẽ, tối giản để ghi lại suy nghĩ, tổ chức ý tưởng và xây dựng cơ sở kiến thức cá nhân—tất cả trong khi giữ dữ liệu của bạn an toàn trên cơ sở hạ tầng của riêng bạn.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+memos là giải pháp thay thế hấp dẫn cho một số nền tảng ghi chú và quản lý kiến thức phổ biến, bao gồm:
+
+- Notion (cho quản lý kiến thức cá nhân)
+- Evernote
+- OneNote
+- Bear Notes
+- Standard Notes
+- Nền tảng wiki thương mại như Confluence (cho các trường hợp sử dụng nhẹ)
+
+## 4. Chức Năng Chính
+
+memos cung cấp một bộ tính năng mạnh mẽ được thiết kế cho việc ghi lại và tổ chức kiến thức hiệu quả:
+
+- **Hỗ trợ Markdown:** Định dạng Markdown đầy đủ với xem trước trực tiếp
+- **Hệ thống Thẻ:** Hệ thống gắn thẻ linh hoạt để tổ chức nội dung
+- **Chức năng Tìm kiếm:** Tìm kiếm toàn văn mạnh mẽ trên tất cả ghi chú
+- **Ưu tiên Quyền riêng tư:** Tất cả dữ liệu được lưu trữ cục bộ, không có phụ thuộc bên ngoài
+- **Hỗ trợ Nhiều Người dùng:** Khả năng cộng tác nhóm
+- **RESTful API:** Truy cập có lập trình vào ghi chú của bạn
+- **Cơ sở dữ liệu SQLite:** Cơ sở dữ liệu nhẹ, dựa trên tệp, không yêu cầu máy chủ cơ sở dữ liệu riêng
+- **Giao diện Dựa trên Web:** Có thể truy cập từ bất kỳ trình duyệt hiện đại nào
+- **Khả năng Xuất:** Sao lưu và xuất dữ liệu của bạn ở nhiều định dạng
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu điểm:
+- **Toàn quyền Sở hữu Dữ liệu:** Ghi chú của bạn không bao giờ rời khỏi máy chủ của bạn
+- **Nhẹ:** Yêu cầu tài nguyên tối thiểu so với các lựa chọn thay thế
+- **Mã nguồn Mở:** Phát triển minh bạch và cải tiến do cộng đồng thúc đẩy
+- **Dễ Triển khai:** Cài đặt dựa trên Docker đơn giản
+- **Giao diện Sạch:** Giao diện trực quan, không gây xao nhãng
+- **Phát triển Tích cực:** Cập nhật thường xuyên và hỗ trợ cộng đồng đang phát triển
+
+### Nhược điểm:
+- **Yêu cầu Tự lưu trữ:** Cần kiến thức kỹ thuật để thiết lập và bảo trì
+- **Trải nghiệm Di động Hạn chế:** Giao diện dựa trên web thay vì ứng dụng di động gốc
+- **Ít Tích hợp hơn:** So với các lựa chọn thương mại đã được thiết lập
+- **Bộ Tính năng Cơ bản:** Thiếu một số tính năng nâng cao của các nền tảng trưởng thành
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu:
+- Máy chủ Ubuntu 20.04+ (hoặc bất kỳ bản phân phối Linux nào)
+- Docker và Docker Compose đã được cài đặt
+- Kiến thức cơ bản về terminal/dòng lệnh
+
+### Cài đặt Từng bước:
+
+1. **Cập nhật Gói Hệ thống:**
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   ```
+
+2. **Cài đặt Docker (nếu chưa được cài đặt):**
+   ```bash
+   sudo apt install docker.io docker-compose -y
+   sudo systemctl enable docker
+   sudo systemctl start docker
+   ```
+
+3. **Tạo Thư mục Dự án:**
+   ```bash
+   mkdir ~/memos && cd ~/memos
+   ```
+
+4. **Tạo Tệp Docker Compose:**
+   ```bash
+   nano docker-compose.yml
+   ```
+
+   Dán cấu hình sau:
+   ```yaml
+   version: "3.8"
+   services:
+     memos:
+       image: neosmemo/memos:latest
+       container_name: memos
+       ports:
+         - "5230:5230"
+       volumes:
+         - ./data:/var/opt/memos
+       restart: unless-stopped
+   ```
+
+5. **Khởi động Container memos:**
+   ```bash
+   sudo docker-compose up -d
+   ```
+
+6. **Xác minh Cài đặt:**
+   ```bash
+   sudo docker ps
+   ```
+   Bạn sẽ thấy container memos đang chạy.
+
+7. **Truy cập memos:**
+   Mở trình duyệt web của bạn và điều hướng đến `http://your-server-ip:5230`
+
+8. **Thiết lập Ban đầu:**
+   - Tạo tài khoản quản trị đầu tiên của bạn
+   - Bắt đầu tạo ghi chú ngay lập tức
+
+### Tùy chọn: Thiết lập Reverse Proxy (cho truy cập tên miền)
+Để sử dụng trong sản xuất, hãy cân nhắc thiết lập Nginx hoặc Caddy làm reverse proxy với mã hóa SSL.
+
+### Bảo trì:
+- **Sao lưu:** Thường xuyên sao lưu thư mục `./data`
+- **Cập nhật:** Kéo image mới nhất và khởi động lại container:
+  ```bash
+  cd ~/memos
+  sudo docker-compose pull
+  sudo docker-compose up -d
+  ```
+
+memos cung cấp một giải pháp thay thế mạnh mẽ, tập trung vào quyền riêng tư cho các nền tảng ghi chú thương mại, mang lại cho bạn toàn quyền kiểm soát dữ liệu với độ phức tạp thiết lập tối thiểu.

--- a/src/content/posts/add-google-adsense-to-your-jekyll-website-vi.md
+++ b/src/content/posts/add-google-adsense-to-your-jekyll-website-vi.md
@@ -1,0 +1,128 @@
+---
+lang: vi
+title: >- 
+  💰 Kiếm Tiền Từ Trang Jekyll Của Bạn 💰: Hướng Dẫn Từng Bước Thêm Google AdSense
+description: >-
+  Học cách tích hợp Google AdSense vào trang Jekyll của bạn và bắt đầu kiếm thu nhập. Hướng dẫn toàn diện này bao gồm mọi thứ từ thiết lập tài khoản đến vị trí đặt quảng cáo tối ưu.
+author: minhpt
+published: 2025-02-18
+category: Self-hosted
+tags: [tutorial, self-hosted, jekyll, Jekyll AdSense, Add Google AdSense Jekyll, Monetize Jekyll Blog, Google AdSense Integration, Jekyll Ads, Jekyll Ad Revenue, Jekyll Ad Placement]
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/google-adsense.jpg
+
+---
+
+Bạn muốn biến niềm đam mê viết lách thành nguồn thu nhập? Nếu bạn đang chạy một trang web hoặc blog sử dụng Jekyll, việc thêm Google AdSense là một cách tuyệt vời để kiếm tiền từ nội dung của bạn. Mặc dù Jekyll nổi tiếng với sự đơn giản và tốc độ, việc tích hợp các dịch vụ bên ngoài như AdSense đôi khi có vẻ khó khăn. Nhưng đừng lo! Hướng dẫn này sẽ hướng dẫn bạn từng bước, đảm bảo bạn có thể thêm AdSense vào trang Jekyll của mình một cách dễ dàng.
+
+### Tại Sao Sử Dụng Google AdSense Với Jekyll?
+
+- **Kiếm Thu Nhập**: Tạo thu nhập từ lưu lượng truy cập trang web của bạn.
+- **Tích hợp Dễ dàng**: Mặc dù cần một vài bước, nhưng khá đơn giản.
+- **Quảng cáo Mục tiêu**: Thuật toán của Google hiển thị quảng cáo phù hợp với khán giả của bạn.
+- **Tùy chỉnh**: Kiểm soát vị trí và giao diện quảng cáo.
+
+### Yêu Cầu
+
+- Tài khoản Google AdSense (đăng ký tại google.com/adsense)
+- Trang web hoặc blog Jekyll.
+- Quyền truy cập vào các tệp HTML của trang web.
+
+#### Bước 1: Lấy Mã AdSense
+
+1. Đăng nhập vào tài khoản Google AdSense của bạn <https://adsense.google.com/start/>.
+2. Điều hướng đến `Site` > `New site`
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/create-new-site.png)
+3. Chọn phương thức xác minh (ví dụ: `Adsense Code snippet`, `Ads.txt snippet`, `Meta tag`)
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/add-code.png)
+
+#### Bước 2: Thêm Mã Xác Minh Vào Trang Jekyll
+
+##### Sử dụng Mã AdSense (Code snippet)
+
+1. Tạo thư mục `_includes` trong dự án Jekyll của bạn
+
+```bash
+cd [du-an-jekyll-cua-ban]
+mkdir _includes
+```
+
+2. Tạo tệp `head.html` trong thư mục `_includes`.
+
+```bash
+touch head.html
+```
+
+3. Sao chép và dán toàn bộ nội dung của `head.html` từ liên kết này: <https://github.com/cotes2020/jekyll-theme-chirpy/blob/master/_includes/head.html>
+4. Tạo tệp `google-adsense.html` trong thư mục `_includes`.
+
+```bash
+touch google-adsense.html
+```
+
+5. Chỉnh sửa tệp `google-adsense.html` với đoạn mã Google AdSense của bạn ở trên.
+
+```text
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=[ID-ca-pub-cua-ban]"
+     crossorigin="anonymous"></script>
+```
+
+1. Chỉnh sửa `head.html`:
+
+```html
+  <head>
+    <!--một số mã phía trên-->
+    {% include metadata-hook.html %}
+    <!--thêm dòng này-->
+    {% include google-adsense.html %} 
+  </head>
+```
+
+##### Sử dụng Mã Ads.txt (snippet)
+
+1. Tạo tệp `ads.txt` trong dự án Jekyll của bạn:
+
+```bash
+  touch ads.txt
+```
+
+2. Chỉnh sửa tệp `ads.txt` với đoạn mã Ads.txt của bạn.
+
+##### Sử dụng Thẻ Meta
+
+1. Chỉnh sửa tệp `head.html` trong thư mục `_includes`.
+2. Thêm thẻ meta Google AdSense bên trong thẻ `<head>`:
+
+```html
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <!--thêm dòng này-->
+  <meta name="google-adsense-account" content="[thẻ-meta-của-ban]">
+  <meta
+    name="viewport"
+    content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+  >
+  <!--một số mã còn lại-->
+</head>
+```
+
+#### Bước 3: Xác Minh Mã và Theo Dõi
+
+1. **Xác Minh AdSense**: Google sẽ xem xét trang web của bạn để đảm bảo tuân thủ chính sách. Quá trình này có thể mất một thời gian.
+2. **Kiểm Tra Hiển Thị Quảng Cáo**: Sau khi được phê duyệt, quảng cáo sẽ bắt đầu xuất hiện trên trang của bạn.
+3. **Theo Dõi Hiệu Suất**: Sử dụng bảng điều khiển AdSense để theo dõi thu nhập và hiệu suất quảng cáo.
+4. **Tối Ưu Vị Trí Đặt Quảng Cáo**: Thử nghiệm với các vị trí đặt quảng cáo khác nhau để tối đa hóa doanh thu.
+
+### Mẹo Thành Công
+
+- **Nội Dung Là Vua**: Tập trung vào việc tạo nội dung chất lượng cao, hấp dẫn.
+- **Thiết Kế Đáp Ứng**: Đảm bảo trang web và quảng cáo của bạn hiển thị tốt trên mọi thiết bị.
+- **Tối Ưu Vị Trí Quảng Cáo**: Tránh đặt quá nhiều quảng cáo hoặc quảng cáo làm gián đoạn trải nghiệm người dùng.
+- **Chính Sách AdSense**: Tuân thủ chính sách của Google AdSense để tránh bị đình chỉ tài khoản.
+
+### Kết Luận
+
+Thêm Google AdSense vào trang Jekyll của bạn là một quy trình đơn giản có thể giúp bạn kiếm tiền từ nội dung. Bằng cách làm theo các bước này và tối ưu vị trí đặt quảng cáo, bạn có thể bắt đầu kiếm thu nhập từ công sức của mình. Hãy nhớ ưu tiên trải nghiệm người dùng và tạo nội dung có giá trị để tối đa hóa thu nhập. Chúc bạn kiếm tiền thành công!- Quay lại trang Google AdSense và nhấp vào nút `Verify`.

--- a/src/content/posts/add-google-analystic-to-your-jekyll-website-with-Chirpy-theme-vi.md
+++ b/src/content/posts/add-google-analystic-to-your-jekyll-website-with-Chirpy-theme-vi.md
@@ -1,0 +1,95 @@
+---
+lang: vi
+title: Thêm Google Analytics vào Trang Jekyll của bạn sử dụng theme Chirpy
+description: >-
+  Hãy cùng tìm hiểu cách thêm Google Analytics vào trang Jekyll của bạn với theme Chirpy. Hướng dẫn này sẽ bao gồm mọi thứ từ thiết lập tài khoản Google Analytics đến xác minh mã theo dõi.
+author: minhpt
+published: 2025-02-18
+category: Self-hosted
+tags: [blog, tutorial, github, jekyll, chirpy, self-hosted, google-analystic]
+---
+
+### Tạo Tài Khoản Google Analytics (nếu bạn chưa có)
+
+* Truy cập [https://analytics.google.com/](https://www.google.com/search?q=https://analytics.google.com/)
+
+* Nhấp "Bắt đầu miễn phí" (hoặc "Đăng nhập" nếu bạn đã có tài khoản).
+
+* Làm theo hướng dẫn để tạo tài khoản. Bạn sẽ cần một tài khoản Google.
+
+### Thiết lập Property cho Trang Jekyll của Bạn
+
+* Sau khi đăng nhập, bạn sẽ được hướng dẫn qua quy trình thiết lập. Nếu không, nhấp "Admin" (biểu tượng bánh răng) ở góc dưới bên trái.
+
+* Trong cột "Account", chọn tài khoản phù hợp (hoặc tạo tài khoản mới).
+
+* Trong cột "Property", nhấp "Create Property."
+
+* Chọn "Web" làm nền tảng.
+
+* Điền các thông tin sau:
+
+  * **Tên trang web:** Tên blog của bạn (ví dụ: "Blog Jekyll Của Tôi").
+
+  * **URL trang web:** URL blog của bạn (ví dụ: <https://yourusername.github.io> hoặc tên miền tùy chỉnh của bạn). Đảm bảo chọn https:// (hoặc http:// nếu trang của bạn sử dụng nó).
+
+  * **Múi giờ Báo cáo:** Chọn múi giờ của bạn.
+
+  * **Tiền tệ:** Đơn vị tiền tệ ưa thích của bạn.
+
+* Nhấp "Create."
+
+### Lấy ID Theo Dõi (Measurement ID)
+
+* Sau khi tạo property, bạn sẽ được đưa đến phần "Data Streams". Nhấp vào "Web" để cấu hình luồng dữ liệu cho trang web của bạn.
+
+* Trên trang chi tiết luồng web, bạn sẽ thấy "Measurement ID" bắt đầu bằng G-. Đây là ID Theo dõi của bạn. Sao chép ID này. Bạn sẽ cần nó ngay sau đây.
+  
+### Thêm ID Theo Dõi vào Trang Jekyll của Bạn (Theme Chirpy)
+
+Chirpy cung cấp cách tích hợp Google Analytics đơn giản. Bạn thường sẽ thêm ID theo dõi vào tệp \_config.yml của trang.
+
+* Mở \_config.yml: Trong thư mục dự án Jekyll của bạn, mở tệp \_config.yml.
+
+* **Thêm Cấu hình Google Analytics:** Thêm các dòng sau vào tệp \_config.yml của bạn, thay thế G-XXXXXXXXXX bằng Measurement ID thực tế của bạn:
+    `google_analytics: G-XXXXXXXXXX`
+
+* **Quan trọng với Chirpy:** Chirpy sử dụng trực tiếp cài đặt google\_analytics. Bạn _không_ cần thêm bất kỳ đoạn mã nào khác vào \_layouts/default.html hoặc các tệp mẫu khác. Chirpy xử lý việc triển khai cho bạn.
+
+### Xây dựng Lại và Triển khai Trang Jekyll
+
+* Chạy bundle exec jekyll serve (hoặc lệnh xây dựng Jekyll thông thường của bạn) để xây dựng lại trang với các thay đổi.
+
+* Triển khai trang của bạn lên GitHub Pages (hoặc bất kỳ nơi nào bạn đang lưu trữ).
+
+### Xác Minh Mã Theo Dõi
+
+* **Truy cập trang web của bạn:** Mở blog của bạn trong trình duyệt web.
+
+* **Sử dụng Báo cáo Thời gian thực của Google Analytics:** Quay lại bảng điều khiển Google Analytics của bạn. Trong menu bên trái, dưới "Reports," nhấp vào "Realtime" -> "Overview."
+
+* **Kiểm tra Hoạt động:** Khi bạn duyệt trang web của mình, bạn sẽ thấy hoạt động của mình trong báo cáo Thời gian thực. Điều này xác nhận mã theo dõi đang hoạt động chính xác. Có thể mất vài phút để dữ liệu hiển thị.
+
+### Khắc phục Sự cố
+
+* **Không có dữ liệu hiển thị?**
+
+  * Kiểm tra kỹ Measurement ID của bạn trong \_config.yml. Đảm bảo đó là ID chính xác.
+
+  * Đảm bảo bạn đã xây dựng lại và triển khai lại trang sau khi thêm ID.
+
+  * Xóa bộ nhớ cache và cookie của trình duyệt.
+
+  * Chờ một chút. Báo cáo thời gian thực thường nhanh, nhưng dữ liệu khác có thể mất đến 24 giờ để xuất hiện.
+
+  * Kiểm tra bảng điều khiển nhà phát triển của trình duyệt (thường mở bằng phím F12) để tìm bất kỳ lỗi JavaScript nào liên quan đến Google Analytics.
+
+* **Sự cố triển khai GitHub Pages?** Đảm bảo cài đặt GitHub Pages của bạn đúng và trang web đang xây dựng thành công.
+
+### Những Lưu Ý Quan Trọng
+
+* **Quyền riêng tư:** Hãy minh bạch với người dùng về việc bạn sử dụng Google Analytics. Cân nhắc thêm chính sách quyền riêng tư vào trang web của bạn.
+
+* **GDPR và các quy định khác:** Nhận thức và tuân thủ các quy định về quyền riêng tư dữ liệu có liên quan, chẳng hạn như GDPR. Bạn có thể cần cấu hình Google Analytics để ẩn danh địa chỉ IP hoặc cung cấp cho người dùng tùy chọn từ chối theo dõi. Tham khảo tài liệu của Google Analytics để biết chi tiết tuân thủ.
+
+Bằng cách làm theo các bước này, bạn sẽ có thể tích hợp thành công Google Analytics vào blog Jekyll của mình bằng theme Chirpy và bắt đầu theo dõi lưu lượng truy cập trang web.

--- a/src/content/posts/create-blog-with-github-papes-and-jekyll-vi.md
+++ b/src/content/posts/create-blog-with-github-papes-and-jekyll-vi.md
@@ -1,0 +1,114 @@
+---
+title: Tạo blog cá nhân với Github Pages và Jekyll sử dụng theme Chirpy
+description: >-
+  Học cách cài đặt, cấu hình và triển khai theme Chirpy Jekyll cho blog của bạn. Hướng dẫn từng bước này bao gồm Dev Containers, thiết lập gốc, tùy chọn tùy chỉnh và các phương pháp triển khai như GitHub Actions.
+author: minhpt
+published: 2025-02-03
+category: Self-hosted
+tags: [blog, tutorial, github, jekyll, chirpy, self-hosted]
+lang: vi
+---
+
+
+Hướng dẫn này sẽ hướng dẫn bạn thiết lập và sử dụng theme Chirpy Jekyll cho trang web của bạn.
+
+### 1. Chọn Điểm Bắt Đầu
+
+* **Khuyến nghị:** Sử dụng **Chirpy Starter** để dễ dàng nâng cấp và cấu hình tối thiểu.
+  * Trên GitHub, điều hướng đến [Chirpy Starter](https://github.com/cotes2020/chirpy-starter) và nhấp "Use this template."
+  * Tạo một kho lưu trữ mới có tên `<tên_người_dùng>.github.io` (thay `<tên_người_dùng>` bằng tên người dùng GitHub thực tế của bạn). Điều này sẽ tự động cấu hình GitHub Pages để lưu trữ trang của bạn.
+
+* **Dành cho Tùy chỉnh Nâng cao:** Fork kho lưu trữ theme chính ([Fork Kho Lưu Trữ Theme](https://tranglc.github.io/posts/getting-started/)).
+  * **Lưu ý:** Tùy chọn này dành cho những người thoải mái với việc sửa đổi Jekyll. Bạn sẽ chịu trách nhiệm quản lý các bản cập nhật và xung đột tiềm ẩn.
+
+### 2. Thiết Lập Môi Trường Phát Triển
+
+* **Khuyến nghị (Windows):** Sử dụng **Dev Containers** để có môi trường cách ly và nhất quán.
+  * **Cài đặt Docker:**
+    * **Windows/macOS:** Cài đặt Docker Desktop từ [Docker](https://www.docker.com/products/docker-desktop/).
+    * **Linux:** Cài đặt Docker Engine từ tài liệu chính thức của Docker.
+  * **Cài đặt VS Code:** Tải xuống và cài đặt VS Code từ [code.visualstudio.com](https://code.visualstudio.com/).
+  * **Cài đặt Extension Dev Containers:** Tìm kiếm "Remote - Containers" trong thị trường extension của VS Code và cài đặt.
+  * **Clone vào Container:**
+    * **Phương pháp 1 (Docker Desktop):** Mở VS Code và sử dụng lệnh "Clone Repository". Chọn kho lưu trữ mới tạo của bạn. VS Code sẽ hướng dẫn bạn tạo Dev Container và mở dự án bên trong nó.
+    * **Phương pháp 2 (Docker Engine):** Clone kho lưu trữ cục bộ. Trong VS Code, mở thư mục và chọn "Reopen in Container." VS Code sẽ tạo và khởi động một container cho dự án của bạn.
+
+* **Thiết lập Gốc (Hệ thống Unix-like):**
+
+  * **Cài đặt Jekyll:** Làm theo hướng dẫn cài đặt Jekyll chính thức: [Jekyll Installation](https://jekyllrb.com/docs/installation/).
+  * **Cài đặt Git:** Nếu chưa có, hãy cài đặt Git từ [git-scm.com](https://git-scm.com/).
+  * **Clone Kho Lưu Trữ của Bạn:** Sử dụng Git để clone kho lưu trữ đã chọn (Starter hoặc theme đã fork) vào máy cục bộ của bạn.
+  * **Khởi tạo (nếu đã fork):** Nếu bạn đã fork theme, chạy `bash tools/init.sh` trong thư mục gốc để khởi tạo kho lưu trữ.
+  * **Cài đặt Phụ thuộc:** Chạy `bundle` trong thư mục gốc của kho lưu trữ để cài đặt các gem Ruby cần thiết.
+
+### 3. Chạy Trang Cục Bộ
+
+* **Khởi động Máy Chủ Jekyll:** Thực hiện lệnh sau trong terminal của bạn:
+
+```bash
+bundle exec jekyll s
+```
+
+* **Truy cập Trang của Bạn:** Mở trình duyệt web và điều hướng đến `http://127.0.0.1:4000/`.
+
+### 4. Tùy Chỉnh
+
+* **Cấu hình:** Chỉnh sửa tệp `_config.yml` để điều chỉnh cài đặt:
+  * `url`: URL gốc của trang web của bạn (ví dụ: `https://yourdomain.com`).
+  * `title`: Tiêu đề trang web của bạn.
+  * `author`: Tên hoặc bút danh của bạn.
+  * `avatar`: URL ảnh đại diện của bạn.
+  * `timezone`: Múi giờ địa phương của bạn.
+  * `lang`: Ngôn ngữ của trang web (ví dụ: `en`, `vi`).
+  * **Lưu ý:** Tham khảo tệp `_config.yml` để biết danh sách đầy đủ các tùy chọn có sẵn.
+
+* **Liên hệ Xã hội:**
+  * Chỉnh sửa tệp `_data/contact.yml` để bật hoặc tắt các liên kết mạng xã hội (ví dụ: Twitter, GitHub, LinkedIn).
+  * Thêm hoặc xóa các tài khoản mạng xã hội khi cần.
+
+* **Kiểu dáng:**
+  * Tùy chỉnh bảng định kiểu bằng cách sửa đổi `assets/css/jekyll-theme-chirpy.scss`.
+  * Thêm CSS tùy chỉnh của bạn ở cuối tệp để tránh xung đột trong các bản cập nhật theme trong tương lai.
+
+* **Tài nguyên Tĩnh:**
+  * **Tùy chỉnh:** Sửa đổi hoặc thay thế các tài nguyên tĩnh hiện có (hình ảnh, JavaScript, v.v.) trong thư mục `assets`.
+  * **Tự lưu trữ:**
+    * Tham khảo kho lưu trữ `_chirpy-static-assets_` để biết hướng dẫn tự lưu trữ tài nguyên tĩnh nhằm cải thiện hiệu suất và kiểm soát.
+    * Cập nhật URL CDN trong `_data/origin/cors.yml` để trỏ đến tài nguyên tự lưu trữ của bạn.
+
+### 5. Triển Khai Trang
+
+* **GitHub Pages với GitHub Actions (Khuyến nghị):**
+
+  * **Đảm bảo Kho lưu trữ Công khai:** Nếu sử dụng gói GitHub miễn phí, kho lưu trữ của bạn phải là công khai.
+  * **Tương thích Nền tảng (nếu sử dụng `Gemfile.lock`):** Nếu máy cục bộ của bạn không phải Linux, hãy cập nhật danh sách nền tảng trong `Gemfile.lock` của bạn:
+
+```bash
+bundle lock --add-platform x86_64-linux
+```
+
+* **Cấu hình GitHub Pages:**
+  * Trong kho lưu trữ GitHub của bạn, vào **Settings** -> **Pages**.
+  * Trong phần **Source**, chọn **"GitHub Actions"** từ menu thả xuống.
+
+* **Triển khai:** Đẩy các thay đổi của bạn lên GitHub. Quy trình làm việc GitHub Actions sẽ tự động xây dựng và triển khai trang của bạn.
+
+* **Triển khai Thủ công:**
+
+  * **Xây dựng Trang:** Chạy lệnh sau trong terminal của bạn:
+
+```bash
+JEKYLL_ENV=production bundle exec jekyll b
+```
+
+> **Tải Tệp Lên:** Các tệp trang đã tạo sẽ nằm trong thư mục `_site`. Tải nội dung của thư mục này lên máy chủ web của bạn (ví dụ: sử dụng FTP, SFTP hoặc rsync).
+{: .prompt-info }
+
+**Video**
+
+<iframe width="100%" height="468" src="https://www.youtube.com/embed/hKMF9LXlO7w" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+
+**Những Lưu Ý Quan Trọng**
+
+* **Project Sites:** Nếu bạn đang sử dụng GitHub Project site hoặc tên miền tùy chỉnh, bạn có thể cần điều chỉnh `baseurl` trong `_config.yml`. Ví dụ: nếu tên dự án của bạn là "my-blog," hãy đặt `baseurl: "/my-blog"`.
+* **Tham khảo Tài liệu:** Để biết thông tin chi tiết, hãy tham khảo tài liệu chính thức của Chirpy và tài liệu Jekyll.

--- a/src/content/posts/draft-vi.md
+++ b/src/content/posts/draft-vi.md
@@ -1,0 +1,23 @@
+---
+lang: vi
+title: Ví Dụ Bản Nháp
+published: 2022-07-01
+tags: [Markdown, Blogging, Demo]
+category: Examples
+draft: true
+---
+
+# Bài Viết Này Là Bản Nháp
+
+Bài viết này hiện đang ở trạng thái nháp và chưa được xuất bản. Do đó, nó sẽ không hiển thị với độc giả. Nội dung vẫn đang trong quá trình hoàn thiện và có thể cần chỉnh sửa và xem xét thêm.
+
+Khi bài viết sẵn sàng xuất bản, bạn có thể cập nhật trường "draft" thành "false" trong Frontmatter:
+
+```markdown
+---
+title: Ví Dụ Bản Nháp
+published: 2024-01-11T04:40:26.381Z
+tags: [Markdown, Blogging, Demo]
+category: Examples
+draft: false
+---

--- a/src/content/posts/enterprise-service-bus-history-birth-and evolution-vi.md
+++ b/src/content/posts/enterprise-service-bus-history-birth-and evolution-vi.md
@@ -1,0 +1,263 @@
+---
+lang: vi
+title: >-
+    Sự Ra Đời và Phát Triển của Enterprise Service Bus: Kết Nối Doanh Nghiệp
+description: >-
+  Khám phá cách Enterprise Service Bus (ESB) cách mạng hóa tích hợp hệ thống bằng cách giải quyết vấn đề 'kiến trúc mì ống'. Tìm hiểu về sự phát triển, khả năng và vị trí của ESB trong kiến trúc hiện đại.
+author: minhpt
+date: 2025-03-29 00:00:00 +0700
+categories: [Develop, Integration]
+published: 2025-03-29
+category: Integration
+tags: [enterprise service bus, ESB architecture, system integration, enterprise integration patterns, spaghetti integration, integration middleware, SOA, service oriented architecture, API gateway, microservices integration]
+mermaid: true
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/esb-cover.jpg
+---
+
+Enterprise Service Bus (ESB) nổi lên như một mẫu kiến trúc quan trọng vào đầu những năm 2000 để giải quyết các thách thức tích hợp mà các tổ chức phải đối mặt khi hệ thống CNTT của họ ngày càng trở nên phức tạp. Hãy cùng khám phá lý do ESB được tạo ra, cách chúng phát triển và vị trí của chúng trong kiến trúc hiện đại.
+
+```mermaid
+flowchart TB
+    subgraph "Enterprise Applications"
+        CRM["CRM System"]
+        ERP["ERP System"]
+        HR["HR System"]
+        Legacy["Legacy System"]
+    end
+    
+    subgraph "Enterprise Service Bus"
+        direction LR
+        MessageBroker["Message Broker"]
+        Transformation["Data Transformation"]
+        Routing["Message Routing"]
+        Security["Security Services"]
+        Orchestration["Service Orchestration"]
+        Monitoring["Monitoring & Management"]
+    end
+    
+    subgraph "External Systems"
+        Partner["Partner Systems"]
+        B2B["B2B Services"]
+        Cloud["Cloud Services"]
+    end
+    
+    CRM <--> ESB-CRM[" "]
+    ERP <--> ESB-ERP[" "]
+    HR <--> ESB-HR[" "]
+    Legacy <--> ESB-Legacy[" "]
+    
+    ESB-CRM <--> MessageBroker
+    ESB-ERP <--> MessageBroker
+    ESB-HR <--> MessageBroker
+    ESB-Legacy <--> MessageBroker
+    
+    MessageBroker <--> Transformation
+    MessageBroker <--> Routing
+    MessageBroker <--> Security
+    MessageBroker <--> Orchestration
+    MessageBroker <--> Monitoring
+    
+    Security <--> ExtInterface[" "]
+    Routing <--> ExtInterface[" "]
+    Transformation <--> ExtInterface[" "]
+    
+    ExtInterface <--> Partner
+    ExtInterface <--> B2B
+    ExtInterface <--> Cloud
+    
+    classDef hidden fill:none,stroke:none
+    class ESB-CRM,ESB-ERP,ESB-HR,ESB-Legacy,ExtInterface hidden
+
+```
+
+## Vấn Đề Tích Hợp
+
+Vào cuối những năm 1990 và đầu những năm 2000, các doanh nghiệp phải đối mặt với một thách thức ngày càng lớn: làm thế nào để kết nối ngày càng nhiều hệ thống khác nhau cần giao tiếp với nhau. Các tổ chức thường có:
+
+- Nhiều hệ thống kế thừa được xây dựng trên các nền tảng khác nhau
+- Nhiều ứng dụng thương mại có sẵn
+- Các giải pháp phần mềm tự xây dựng
+- Yêu cầu ngày càng tăng về kết nối với các hệ thống và đối tác bên ngoài
+
+Cách tiếp cận ban đầu là tích hợp điểm-điểm, nơi mỗi hệ thống cần giao tiếp với một hệ thống khác sẽ có một kết nối trực tiếp. Cách tiếp cận này nhanh chóng trở nên không thể quản lý được khi số lượng kết nối tăng theo cấp số nhân với mỗi hệ thống mới (n*(n-1)/2 kết nối cho n hệ thống).
+
+## Sự Xuất Hiện của Enterprise Service Bus
+
+ESB xuất hiện như một giải pháp cho vấn đề "tích hợp mì ống". Thuật ngữ này lần đầu tiên được phổ biến vào khoảng năm 2002 bởi các nhà phân tích và nhà cung cấp giải pháp tích hợp. Khái niệm này vay mượn ý tưởng từ các hệ thống nhắn tin trước đó và các nền tảng EAI (Enterprise Application Integration) nhưng giới thiệu một kiến trúc dạng bus tiêu chuẩn hóa hơn.
+
+```mermaid
+flowchart TD
+    CRM[CRM System] <--> ERP[ERP System]
+    CRM <--> HR[HR System]
+    CRM <--> Warehouse[Warehouse Management]
+    CRM <--> Accounting[Accounting System]
+    CRM <--> eCommerce[eCommerce Platform]
+    CRM <--> Mobile[Mobile App]
+    
+    ERP <--> HR
+    ERP <--> Warehouse
+    ERP <--> Accounting
+    ERP <--> eCommerce
+    ERP <--> BI[Business Intelligence]
+    ERP <--> POS[Point of Sale]
+    
+    HR <--> Payroll[Payroll System]
+    HR <--> Recruiting[Recruiting Platform]
+    HR <--> TimeTracking[Time Tracking]
+    
+    Accounting <--> Banking[Banking Interface]
+    Accounting <--> Tax[Tax Reporting]
+    Accounting <--> Payroll
+    
+    eCommerce <--> Inventory[Inventory System]
+    eCommerce <--> Payment[Payment Gateway]
+    eCommerce <--> Shipping[Shipping Provider]
+    eCommerce <--> CMS[Content Management]
+    
+    Warehouse <--> Shipping
+    Warehouse <--> Inventory
+    Warehouse <--> POS
+    
+    Legacy[Legacy System] <--> CRM
+    Legacy <--> ERP
+    Legacy <--> HR
+    Legacy <--> Accounting
+    
+    Partners[Partner Systems] <--> ERP
+    Partners <--> eCommerce
+    Partners <--> CRM
+    
+    Mobile <--> eCommerce
+    Mobile <--> CMS
+    
+    POS <--> Inventory
+    POS <--> Payment
+    
+    BI <--> CRM
+    BI <--> HR
+    BI <--> Accounting
+    BI <--> eCommerce
+    BI <--> Warehouse
+    
+    style CRM fill:#f9f,stroke:#333,stroke-width:2px
+    style ERP fill:#bbf,stroke:#333,stroke-width:2px
+    style HR fill:#bfb,stroke:#333,stroke-width:2px
+    style Accounting fill:#ffb,stroke:#333,stroke-width:2px
+    style eCommerce fill:#fbf,stroke:#333,stroke-width:2px
+    style Warehouse fill:#bff,stroke:#333,stroke-width:2px
+    style Legacy fill:#fbb,stroke:#333,stroke-width:2px
+```
+
+ESB hoạt động như một xương sống trung tâm mà qua đó tất cả các dịch vụ và ứng dụng giao tiếp, thay thế nhiều kết nối điểm-điểm bằng một điểm kết nối logic duy nhất.
+
+## Khả Năng Cốt Lõi của ESB
+
+1. **Phần mềm trung gian hướng thông điệp**: Nền tảng của hầu hết các ESB, cung cấp nhắn tin bất đồng bộ đáng tin cậy
+2. **Chuyển đổi giao thức**: Dịch giữa các giao thức truyền thông khác nhau (HTTP, JMS, SOAP, v.v.)
+3. **Chuyển đổi dữ liệu**: Chuyển đổi định dạng dữ liệu giữa các hệ thống (XML, JSON, CSV, định dạng độc quyền)
+4. **Định tuyến thông minh**: Điều hướng thông điệp dựa trên nội dung hoặc quy tắc
+5. **Điều phối dịch vụ**: Phối hợp trình tự tương tác dịch vụ
+6. **Bảo mật**: Xác thực, phân quyền và mã hóa
+7. **Giám sát và quản lý**: Theo dõi luồng thông điệp và tình trạng hệ thống
+
+## Sự Phát Triển Kỹ Thuật
+
+ESB đã phát triển qua nhiều giai đoạn:
+
+### Giai đoạn 1: ESB Độc Quyền (2002-2008)
+
+Các nhà cung cấp như IBM, TIBCO và BEA (sau này được Oracle mua lại) đã phát triển các nền tảng ESB độc quyền toàn diện. Đây thường là các giải pháp nặng nề đòi hỏi đầu tư đáng kể.
+
+### Giai đoạn 2: Mã Nguồn Mở và Tiêu Chuẩn (2008-2014)
+
+Sự trỗi dậy của các ESB mã nguồn mở như Mule, ServiceMix và WSO2 đã dân chủ hóa quyền truy cập vào công nghệ ESB. Các tiêu chuẩn như JBI (Java Business Integration) và sau đó là OSGi (Open Service Gateway initiative) đã cố gắng tiêu chuẩn hóa các thành phần ESB.
+
+```mermaid
+flowchart LR
+    subgraph "1990s: Point-to-Point"
+        direction TB
+        P2P_App1["App 1"] <--> P2P_App2["App 2"]
+        P2P_App1 <--> P2P_App3["App 3"]
+        P2P_App2 <--> P2P_App3
+        P2P_App1 <--> P2P_App4["App 4"]
+        P2P_App2 <--> P2P_App4
+        P2P_App3 <--> P2P_App4
+    end
+    
+    subgraph "2000s: Enterprise Service Bus"
+        direction TB
+        ESB["ESB"]
+        ESB_App1["App 1"] <--> ESB
+        ESB_App2["App 2"] <--> ESB
+        ESB_App3["App 3"] <--> ESB
+        ESB_App4["App 4"] <--> ESB
+    end
+    
+    subgraph "2010s+: Microservices"
+        direction TB
+        MS_App1["Microservice 1"] <--> API_GW["API Gateway"]
+        MS_App2["Microservice 2"] <--> API_GW
+        MS_App3["Microservice 3"] <--> API_GW
+        MS_App4["Microservice 4"] <--> API_GW
+        MS_App1 <-.-> MS_App2
+        MS_App2 <-.-> MS_App3
+        MS_App3 <-.-> MS_App4
+        
+        MS_App1 <-.-> MessageQ["Message Queue"]
+        MS_App2 <-.-> MessageQ
+        MS_App3 <-.-> MessageQ
+        MS_App4 <-.-> MessageQ
+    end
+    
+    P2P_App1 -.-> |"Evolution"| ESB_App1
+    ESB -.-> |"Evolution"| API_GW
+
+```
+
+### Giai đoạn 3: ESB trong Kỷ Nguyên Đám Mây và API (2014-Nay)
+
+Khi điện toán đám mây và microservices trở nên phổ biến, ESB đã thích nghi để trở nên nhẹ nhàng hơn và tập trung vào API. Nhiều nhà cung cấp ESB truyền thống đã đổi tên sản phẩm của họ thành "Nền tảng Quản lý API" hoặc "Nền tảng Tích hợp dưới dạng Dịch vụ" (iPaaS).
+
+## Tại Sao ESB Đôi Khi Thất Bại
+
+Mặc dù đầy hứa hẹn, ESB không phải lúc nào cũng thành công:
+
+1. **Độ phức tạp**: Nhiều triển khai ESB trở nên quá phức tạp và khó bảo trì
+2. **Nút thắt tập trung**: ESB có thể trở thành một điểm lỗi duy nhất
+3. **Thách thức quản trị**: Nếu không có quản trị phù hợp, ESB vẫn có thể dẫn đến hỗn loạn tích hợp
+4. **Chi phí hiệu suất**: Các lớp xử lý bổ sung làm tăng độ trễ
+5. **Chi phí cao**: Các giải pháp ESB doanh nghiệp thường đi kèm với chi phí cấp phép đáng kể
+
+## ESBs so với Các Phương Pháp Tích Hợp Hiện Đại
+
+Sự trỗi dậy của microservices, container hóa và kiến trúc cloud-native đã thay đổi bối cảnh tích hợp:
+
+| Phương pháp ESB | Phương pháp Hiện đại |
+|-----------------|----------------------|
+| Broker tập trung | Giao tiếp phân tán |
+| Chuyển đổi nặng nề | API tiêu chuẩn hóa (REST, GraphQL) |
+| Điều phối phức tạp | Biên đạo giữa các dịch vụ |
+| Triển khai nặng nề | Dịch vụ nhẹ, container hóa |
+| Nền tảng tích hợp nguyên khối | Công cụ chuyên biệt, được xây dựng có mục đích
+
+## ESB Đã Chết Chưa?
+
+Chưa hẳn. Mặc dù các mẫu ESB thuần túy không còn được ưa chuộng trong nhiều dự án mới, các vấn đề cốt lõi mà ESB giải quyết vẫn tồn tại. Nhiều tổ chức đã tìm ra điểm trung gian:
+
+- Sử dụng các công cụ tích hợp nhẹ, mô-đun
+- Kết hợp API gateway với hàng đợi thông điệp
+- Áp dụng service mesh cho giao tiếp microservice
+- Sử dụng kiến trúc hướng sự kiện
+
+Các doanh nghiệp lớn với đầu tư đáng kể vào hệ thống kế thừa thường duy trì ESB cho các hệ thống hiện có trong khi áp dụng các mẫu mới hơn cho phát triển mới.
+
+## Bài Học Kinh Nghiệm
+
+Sự trỗi dậy và phát triển của ESB dạy chúng ta những bài học quý giá cho kiến trúc CNTT:
+
+1. **Tích hợp là tất yếu** - Các hệ thống sẽ luôn cần giao tiếp với nhau
+2. **Cân bằng tập trung và phân tán** - Quá nhiều một trong hai sẽ tạo ra vấn đề
+3. **Tiêu chuẩn hóa rất quan trọng** - Giao diện chung giảm độ phức tạp tích hợp
+4. **Thích ứng với công nghệ thay đổi** - Các phương pháp tích hợp phải phát triển cùng với bối cảnh công nghệ
+
+Dù bạn đang sử dụng ESB truyền thống, API gateway hiện đại hay kết hợp các mẫu tích hợp, thách thức cơ bản vẫn giống nhau: cho phép các hệ thống đa dạng hoạt động cùng nhau hiệu quả trong khi duy trì tính linh hoạt, hiệu suất và độ tin cậy.

--- a/src/content/posts/expressive-code-vi.md
+++ b/src/content/posts/expressive-code-vi.md
@@ -1,0 +1,313 @@
+---
+lang: vi
+title: Ví Dụ Expressive Code
+published: 2024-04-10
+description: Các khối mã trông như thế nào trong Markdown sử dụng Expressive Code.
+tags: [Markdown, Blogging, Demo]
+category: Examples
+draft: false
+---
+
+Ở đây, chúng ta sẽ khám phá cách các khối mã hiển thị bằng [Expressive Code](https://expressive-code.com/). Các ví dụ được cung cấp dựa trên tài liệu chính thức, bạn có thể tham khảo để biết thêm chi tiết.
+
+## Expressive Code
+
+### Tô Màu Cú Pháp
+
+[Tô Màu Cú Pháp](https://expressive-code.com/key-features/syntax-highlighting/)
+
+#### Tô màu cú pháp thông thường
+
+```js
+console.log('Mã này được tô màu cú pháp!')
+```
+
+#### Hiển thị chuỗi thoát ANSI
+
+```ansi
+Màu ANSI:
+- Thường: [31mĐỏ[0m [32mXanh lá[0m [33mVàng[0m [34mXanh dương[0m [35mTím[0m [36mXanh cyan[0m
+- Đậm:   [1;31mĐỏ[0m [1;32mXanh lá[0m [1;33mVàng[0m [1;34mXanh dương[0m [1;35mTím[0m [1;36mXanh cyan[0m
+- Mờ:    [2;31mĐỏ[0m [2;32mXanh lá[0m [2;33mVàng[0m [2;34mXanh dương[0m [2;35mTím[0m [2;36mXanh cyan[0m
+
+256 màu (hiển thị màu 160-177):
+[38;5;160m160 [38;5;161m161 [38;5;162m162 [38;5;163m163 [38;5;164m164 [38;5;165m165[0m
+[38;5;166m166 [38;5;167m167 [38;5;168m168 [38;5;169m169 [38;5;170m170 [38;5;171m171[0m
+[38;5;172m172 [38;5;173m173 [38;5;174m174 [38;5;175m175 [38;5;176m176 [38;5;177m177[0m
+
+Màu RGB đầy đủ:
+[38;2;34;139;34mForestGreen - RGB(34, 139, 34)[0m
+
+Định dạng văn bản: [1mĐậm[0m [2mMờ[0m [3mNghiêng[0m [4mGạch chân[0m
+```
+
+### Khung Trình Soạn Thảo & Terminal
+
+[Khung Trình Soạn Thảo & Terminal](https://expressive-code.com/key-features/frames/)
+
+#### Khung trình soạn thảo mã
+
+```js title="my-test-file.js"
+console.log('Ví dụ thuộc tính Title')
+```
+
+---
+
+```html
+<!-- src/content/index.html -->
+Ví dụ bình luận tên tệp
+```
+
+#### Khung terminal
+
+```bash
+echo "Khung terminal này không có tiêu đề"
+```
+
+---
+
+```powershell title="Ví dụ terminal PowerShell"
+Write-Output "Cái này có tiêu đề!"
+```
+
+#### Ghi đè loại khung
+
+```sh frame="none"
+echo "Nhìn này, không có khung!"
+```
+
+---
+
+```ps frame="code" title="PowerShell Profile.ps1"
+# Nếu không ghi đè, đây sẽ là khung terminal
+function Watch-Tail { Get-Content -Tail 20 -Wait $args }
+New-Alias tail Watch-Tail
+```
+
+### Đánh Dấu Văn Bản & Dòng
+
+[Đánh Dấu Văn Bản & Dòng](https://expressive-code.com/key-features/text-markers/)
+
+#### Đánh dấu toàn bộ dòng & phạm vi dòng
+
+```js {1, 4, 7-8}
+// Dòng 1 - được đánh dấu bằng số dòng
+// Dòng 2
+// Dòng 3
+// Dòng 4 - được đánh dấu bằng số dòng
+// Dòng 5
+// Dòng 6
+// Dòng 7 - được đánh dấu bằng phạm vi "7-8"
+// Dòng 8 - được đánh dấu bằng phạm vi "7-8"
+```
+
+#### Chọn loại đánh dấu dòng (mark, ins, del)
+
+```js title="line-markers.js" del={2} ins={3-4} {6}
+function demo() {
+  console.log('dòng này được đánh dấu là đã xóa')
+  // Dòng này và dòng tiếp theo được đánh dấu là đã thêm
+  console.log('đây là dòng thứ hai được thêm vào')
+
+  return 'dòng này sử dụng loại đánh dấu mặc định trung tính'
+}
+```
+
+#### Thêm nhãn cho đánh dấu dòng
+
+```jsx {"1":5} del={"2":7-8} ins={"3":10-12}
+// labeled-line-markers.jsx
+<button
+  role="button"
+  {...props}
+  value={value}
+  className={buttonClassName}
+  disabled={disabled}
+  active={active}
+>
+  {children &&
+    !active &&
+    (typeof children === 'string' ? <span>{children}</span> : children)}
+</button>
+```
+
+#### Thêm nhãn dài trên dòng riêng
+
+```jsx {"1. Cung cấp giá trị prop ở đây:":5-6} del={"2. Xóa trạng thái disabled và active:":8-10} ins={"3. Thêm dòng này để hiển thị children bên trong button:":12-15}
+// labeled-line-markers.jsx
+<button
+  role="button"
+  {...props}
+
+  value={value}
+  className={buttonClassName}
+
+  disabled={disabled}
+  active={active}
+
+>
+
+  {children &&
+    !active &&
+    (typeof children === 'string' ? <span>{children}</span> : children)}
+</button>
+```
+
+#### Sử dụng cú pháp giống diff
+
+```diff
++dòng này sẽ được đánh dấu là đã thêm
+-dòng này sẽ được đánh dấu là đã xóa
+đây là dòng thông thường
+```
+
+---
+
+```diff
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,4 @@
++đây là một tệp diff thực tế
+-tất cả nội dung sẽ không bị sửa đổi
+không có khoảng trắng nào bị loại bỏ
+```
+
+#### Kết hợp tô màu cú pháp với cú pháp giống diff
+
+```diff lang="js"
+  function thisIsJavaScript() {
+    // Toàn bộ khối này được tô màu như JavaScript,
+    // và chúng ta vẫn có thể thêm đánh dấu diff!
+-   console.log('Mã cũ cần xóa')
++   console.log('Mã mới sáng bóng!')
+  }
+```
+
+#### Đánh dấu văn bản riêng lẻ trong dòng
+
+```js "văn bản đã cho"
+function demo() {
+  // Đánh dấu bất kỳ văn bản nào trong dòng
+  return 'Nhiều kết quả khớp của văn bản đã cho được hỗ trợ';
+}
+```
+
+#### Biểu thức chính quy
+
+```ts /ye[sp]/
+console.log('Các từ yes và yep sẽ được đánh dấu.')
+```
+
+#### Thoát dấu gạch chéo
+
+```sh /\/ho.*\//
+echo "Test" > /home/test.txt
+```
+
+#### Chọn loại đánh dấu trong dòng (mark, ins, del)
+
+```js "return true;" ins="đã chèn" del="đã xóa"
+function demo() {
+  console.log('Đây là các loại đánh dấu đã chèn và đã xóa');
+  // Câu lệnh return sử dụng loại đánh dấu mặc định
+  return true;
+}
+```
+
+### Ngắt Dòng Tự Động
+
+[Ngắt Dòng Tự Động](https://expressive-code.com/key-features/word-wrap/)
+
+#### Cấu hình ngắt dòng theo khối
+
+```js wrap
+// Ví dụ với ngắt dòng
+function getLongString() {
+  return 'Đây là một chuỗi rất dài có thể sẽ không vừa với không gian có sẵn trừ khi container cực kỳ rộng'
+}
+```
+
+---
+
+```js wrap=false
+// Ví dụ với wrap=false
+function getLongString() {
+  return 'Đây là một chuỗi rất dài có thể sẽ không vừa với không gian có sẵn trừ khi container cực kỳ rộng'
+}
+```
+
+#### Cấu hình thụt lề cho dòng ngắt
+
+```js wrap preserveIndent
+// Ví dụ với preserveIndent (được bật mặc định)
+function getLongString() {
+  return 'Đây là một chuỗi rất dài có thể sẽ không vừa với không gian có sẵn trừ khi container cực kỳ rộng'
+}
+```
+
+---
+
+```js wrap preserveIndent=false
+// Ví dụ với preserveIndent=false
+function getLongString() {
+  return 'Đây là một chuỗi rất dài có thể sẽ không vừa với không gian có sẵn trừ khi container cực kỳ rộng'
+}
+```
+
+## Phần Có Thể Thu Gọn
+
+[Phần Có Thể Thu Gọn](https://expressive-code.com/plugins/collapsible-sections/)
+
+```js collapse={1-5, 12-14, 21-24}
+// Tất cả mã thiết lập boilerplate này sẽ được thu gọn
+import { someBoilerplateEngine } from '@example/some-boilerplate'
+import { evenMoreBoilerplate } from '@example/even-more-boilerplate'
+
+const engine = someBoilerplateEngine(evenMoreBoilerplate())
+
+// Phần mã này sẽ hiển thị theo mặc định
+engine.doSomething(1, 2, 3, calcFn)
+
+function calcFn() {
+  // Bạn có thể có nhiều phần thu gọn
+  const a = 1
+  const b = 2
+  const c = a + b
+
+  // Phần này sẽ vẫn hiển thị
+  console.log(`Kết quả tính toán: ${a} + ${b} = ${c}`)
+  return c
+}
+
+// Tất cả mã này đến cuối khối sẽ được thu gọn lại
+engine.closeConnection()
+engine.freeMemory()
+engine.shutdown({ reason: 'Kết thúc ví dụ mã boilerplate' })
+```
+
+## Số Dòng
+
+[Số Dòng](https://expressive-code.com/plugins/line-numbers/)
+
+### Hiển thị số dòng theo khối
+
+```js showLineNumbers
+// Khối mã này sẽ hiển thị số dòng
+console.log('Lời chào từ dòng 2!')
+console.log('Tôi đang ở dòng 3')
+```
+
+---
+
+```js showLineNumbers=false
+// Số dòng bị tắt cho khối này
+console.log('Xin chào?')
+console.log('Xin lỗi, bạn có biết tôi đang ở dòng nào không?')
+```
+
+### Thay đổi số dòng bắt đầu
+
+```js showLineNumbers startLineNumber=5
+console.log('Lời chào từ dòng 5!')
+console.log('Tôi đang ở dòng 6')
+```

--- a/src/content/posts/install-ollama-and-open-webui-with-docker-vi.md
+++ b/src/content/posts/install-ollama-and-open-webui-with-docker-vi.md
@@ -1,0 +1,123 @@
+---
+lang: vi
+title: Thiết lập Open WebUI với Ollama & Docker Desktop
+description: >-
+  Học cách thiết lập Open WebUI với Ollama và Docker Desktop để tương tác với mô hình AI cục bộ. Hướng dẫn từng bước này hoàn hảo cho nhà phát triển AI và blogger.
+author: minhpt
+published: 2025-02-03
+category: Self-hosted
+tags: [tutorial, self-hosted, AI, docker, ollama, open webui]
+---
+
+Bài đăng blog này sẽ hướng dẫn bạn thiết lập **Open WebUI**, một giao diện thân thiện với người dùng, với **Ollama**, một framework nhẹ và có thể mở rộng để chạy các mô hình ngôn ngữ lớn, tất cả được container hóa với **Docker Desktop**. Thiết lập này hoàn hảo cho các nhà phát triển AI và blogger muốn thử nghiệm và trình diễn các mô hình AI cục bộ, mang lại quy trình làm việc hợp lý và hiệu quả.
+
+### Tại Sao Stack Này?
+
+* **Open WebUI**: Cung cấp giao diện web đẹp mắt và trực quan để tương tác với các mô hình ngôn ngữ. Quên giao diện dòng lệnh đi – Open WebUI mang đến trải nghiệm trực quan và thân thiện, lý tưởng cho demo và sáng tạo nội dung.
+* **Ollama**: Đơn giản hóa quy trình chạy và quản lý các mô hình ngôn ngữ lớn trên máy cục bộ của bạn. Nó xử lý sự phức tạp của việc phục vụ mô hình, giúp bạn tập trung vào việc sử dụng các mô hình.
+* **Docker Desktop**: Container hóa ở dạng tốt nhất. Docker đảm bảo môi trường của bạn nhất quán, cách ly và dễ tái tạo. Nó loại bỏ xung đột phụ thuộc và đơn giản hóa việc triển khai, giúp việc thiết lập trở nên dễ dàng trên các hệ điều hành khác nhau.
+
+Cùng nhau, những công cụ này tạo ra một nền tảng mạnh mẽ và thân thiện cho việc khám phá AI và tạo nội dung.
+
+### Yêu Cầu
+
+Trước khi bắt đầu, hãy đảm bảo bạn đã cài đặt những thứ sau:
+
+1. **Docker Desktop**: Tải xuống và cài đặt [Docker Desktop](https://www.google.com/url?sa=E&source=gmail&q=https://www.docker.com/products/docker-desktop/). Làm theo hướng dẫn cài đặt cho hệ điều hành của bạn (Windows, macOS hoặc Linux).
+2. **Ollama**: Tải xuống và cài đặt [Ollama](https://www.google.com/url?sa=E&source=gmail&q=https://ollama.com/). Ollama cung cấp trình cài đặt cho macOS và Linux. Đối với người dùng Windows, Ollama hoạt động liền mạch trong WSL 2 (Windows Subsystem for Linux).
+
+### Hướng Dẫn Thiết Lập Từng Bước
+
+Hãy cùng thiết lập mọi thứ! Làm theo các bước đơn giản sau:
+
+**Bước 1: Xác Minh Cài đặt Docker Desktop**
+
+* Mở terminal hoặc command prompt và chạy: `docker --version`.
+* Bạn sẽ thấy thông tin phiên bản Docker nếu cài đặt thành công.
+* Đảm bảo Docker Desktop đang chạy trong nền.
+
+**Bước 2: Chạy Ollama trong Docker**
+
+Mặc dù Ollama được cài đặt cục bộ, trong thiết lập này, chúng ta sẽ tận dụng Docker để chạy nó. Điều này giữ cho môi trường của chúng ta sạch sẽ và nhất quán.
+
+* Trong terminal của bạn, kéo image Docker Ollama:
+
+    ```bash
+    docker pull ollama/ollama
+    ```
+
+* Sau khi image được kéo, chạy Ollama:
+
+    ```bash
+    docker run -d -p 11434:11434 --name ollama ollama/ollama
+    ```
+
+  * `-d`: Chạy container ở chế độ tách rời (nền).
+  * `-p 11434:11434`: Ánh xạ cổng 11434 trên máy chủ của bạn đến cổng 11434 trong container (cổng mặc định của Ollama).
+  * `--name ollama`: Gán tên "ollama" cho container để quản lý dễ dàng.
+  * `ollama/ollama`: Chỉ định image Docker để sử dụng.
+
+**Bước 3: Triển Khai Open WebUI với Docker Compose**
+
+Docker Compose đơn giản hóa việc triển khai các ứng dụng Docker đa container. Chúng ta sẽ sử dụng nó để triển khai Open WebUI.
+
+* Tạo một thư mục cho dự án của bạn (ví dụ: `open-webui-ollama`) và điều hướng vào đó:
+
+    ```bash
+    mkdir open-webui-ollama
+    cd open-webui-ollama
+    ```
+
+* Tạo một tệp có tên `docker-compose.yml` bên trong thư mục này và dán nội dung sau:
+
+    ```yaml
+    version: '3'
+    services:
+    open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    ports:
+      - 3000:8080
+    environment:
+    OLLAMA_API_BASE_URL: http://ollama:11434/v1
+    volumes:
+      - open-webui:/app/data
+
+    volumes:
+    open-webui:
+    driver: local
+    ```
+
+  * Tệp `docker-compose.yml` này định nghĩa một dịch vụ (mặc dù chúng ta chỉ định nghĩa rõ ràng một, `open-webui`, và ngầm dựa vào container `ollama` chúng ta đã khởi động ở bước trước):
+    * `open-webui`: Định nghĩa dịch vụ Open WebUI.
+      * `image`: Chỉ định image Docker cho Open WebUI.
+      * `ports`: Ánh xạ cổng 3000 trên máy chủ đến cổng 8080 trong container (cổng của Open WebUI). Bạn sẽ truy cập Open WebUI qua `http://localhost:3000`.
+      * `environment`: Đặt biến môi trường `OLLAMA_API_BASE_URL` để trỏ Open WebUI đến container Ollama của chúng ta. **Lưu ý:** Chúng ta sử dụng `http://ollama:11434/v1` vì Docker Compose, trong các thiết lập phức tạp hơn, có thể tạo một mạng nơi các container có thể phân giải lẫn nhau bằng tên. Trong trường hợp đơn giản của chúng ta, vì chúng ta chạy Ollama riêng biệt, điều này có thể không phân giải trực tiếp. Tuy nhiên, để mở rộng trong tương lai và các thiết lập Docker phức tạp hơn, đây là thực hành tốt. Đối với thiết lập đơn giản này, `http://localhost:11434/v1` cũng sẽ hoạt động nếu bạn gặp sự cố.
+      * `volumes`: Gắn một volume Docker có tên `open-webui` để lưu trữ dữ liệu Open WebUI.
+
+* Khởi động Open WebUI bằng Docker Compose:
+
+    ```bash
+    docker-compose up -d
+    ```
+
+  * `docker-compose up`: Tạo và khởi động các dịch vụ được định nghĩa trong `docker-compose.yml`.
+  * `-d`: Chạy các dịch vụ ở chế độ tách rời (nền).
+
+**Bước 4: Truy Cập Open WebUI trong Trình Duyệt**
+
+* Mở trình duyệt web của bạn và điều hướng đến `http://localhost:3000`.
+* Bạn sẽ thấy giao diện Open WebUI.
+
+**Bước 5: Kết Nối với Ollama**
+
+* Theo mặc định, Open WebUI được cấu hình để kết nối với Ollama chạy tại `http://ollama:11434/v1`. Nếu bạn sử dụng `docker-compose.yml` như đã cung cấp và chạy container `ollama` như hướng dẫn, nó sẽ tự động kết nối.
+* Nếu bạn gặp sự cố, hoặc nếu bạn đang chạy Ollama cục bộ (không trong Docker), bạn có thể cần điều chỉnh `OLLAMA_API_BASE_URL`. Bạn thường có thể cấu hình điều này trong giao diện cài đặt Open WebUI nếu cần.
+
+**Bước 6: Bắt Đầu Trò Chuyện!**
+
+* Khám phá giao diện Open WebUI. Bạn có thể chọn và tải xuống các mô hình trực tiếp trong UI (được hỗ trợ bởi Ollama).
+* Bắt đầu trò chuyện với các mô hình AI bạn đã chọn!
+
+### Kết Luận
+
+Chúc mừng! Bạn đã thiết lập thành công Open WebUI với Ollama và Docker Desktop. Bạn hiện có một môi trường AI cục bộ mạnh mẽ để thử nghiệm với các mô hình ngôn ngữ, tạo nội dung blog và khám phá thế giới AI thú vị.

--- a/src/content/posts/markdown-extended-vi.md
+++ b/src/content/posts/markdown-extended-vi.md
@@ -1,0 +1,85 @@
+---
+lang: vi
+title: Tính Năng Markdown Mở Rộng
+published: 2024-05-01
+updated: 2024-11-29
+description: 'Đọc thêm về các tính năng Markdown trong Fuwari'
+image: ''
+tags: [Demo, Example, Markdown, Fuwari]
+category: 'Examples'
+draft: false 
+---
+
+## Thẻ Kho Lưu Trữ GitHub
+Bạn có thể thêm các thẻ động liên kết đến kho lưu trữ GitHub, khi trang tải, thông tin kho lưu trữ được lấy từ API GitHub. 
+
+::github{repo="Fabrizz/MMM-OnSpotify"}
+
+Tạo thẻ kho lưu trữ GitHub với mã `::github{repo="<owner>/<repo>"}`.
+
+```markdown
+::github{repo="saicaca/fuwari"}
+```
+
+## Admonitions
+
+Các loại admonitions sau được hỗ trợ: `note` `tip` `important` `warning` `caution`
+
+:::note
+Thông tin nổi bật mà người dùng nên lưu ý, ngay cả khi đọc lướt qua.
+:::
+
+:::tip
+Thông tin tùy chọn giúp người dùng thành công hơn.
+:::
+
+:::important
+Thông tin quan trọng cần thiết để người dùng thành công.
+:::
+
+:::warning
+Nội dung quan trọng yêu cầu sự chú ý ngay lập tức do rủi ro tiềm ẩn.
+:::
+
+:::caution
+Hậu quả tiêu cực tiềm ẩn của một hành động.
+:::
+
+### Cú Pháp Cơ Bản
+
+```markdown
+:::note
+Thông tin nổi bật mà người dùng nên lưu ý, ngay cả khi đọc lướt qua.
+:::
+
+:::tip
+Thông tin tùy chọn giúp người dùng thành công hơn.
+:::
+```
+
+### Tiêu Đề Tùy Chỉnh
+
+Tiêu đề của admonition có thể được tùy chỉnh.
+
+:::note[TIÊU ĐỀ TÙY CHỈNH CỦA TÔI]
+Đây là một note với tiêu đề tùy chỉnh.
+:::
+
+```markdown
+:::note[TIÊU ĐỀ TÙY CHỈNH CỦA TÔI]
+Đây là một note với tiêu đề tùy chỉnh.
+:::
+```
+
+### Cú Pháp GitHub
+
+> [!TIP]
+> [Cú pháp GitHub](https://github.com/orgs/community/discussions/16925) cũng được hỗ trợ.
+
+```
+> [!NOTE]
+> Cú pháp GitHub cũng được hỗ trợ.
+
+> [!TIP]
+> Cú pháp GitHub cũng được hỗ trợ.
+```

--- a/src/content/posts/markdown-vi.md
+++ b/src/content/posts/markdown-vi.md
@@ -1,0 +1,166 @@
+---
+lang: vi
+title: Ví Dụ Markdown
+published: 2023-10-01
+description: Một ví dụ đơn giản về bài đăng blog Markdown.
+tags: [Markdown, Blogging, Demo]
+category: Examples
+draft: false
+---
+
+# Tiêu đề h1
+
+Các đoạn văn được phân cách bằng một dòng trống.
+
+Đoạn thứ 2. _Nghiêng_, **đậm**, và `mã đơn`. Danh sách các mục
+trông như thế này:
+
+- mục này
+- mục kia
+- mục khác
+
+Lưu ý rằng --- không tính dấu sao --- nội dung văn bản thực tế
+bắt đầu ở cột thứ 4.
+
+> Trích dẫn khối được
+> viết như thế này.
+>
+> Chúng có thể trải dài nhiều đoạn,
+> nếu bạn muốn.
+
+Sử dụng 3 dấu gạch ngang cho em-dash. Sử dụng 2 dấu gạch ngang cho phạm vi (ví dụ: "tất cả nằm trong chương 12--14"). Ba dấu chấm ... sẽ được chuyển đổi thành dấu ba chấm.
+Unicode được hỗ trợ. ☺
+
+## Tiêu đề h2
+
+Đây là danh sách đánh số:
+
+1. mục đầu tiên
+2. mục thứ hai
+3. mục thứ ba
+
+Lưu ý lại rằng văn bản thực tế bắt đầu ở cột thứ 4 (4 ký tự từ bên trái). Đây là một mẫu mã:
+
+    # Hãy để tôi nhắc lại ...
+    for i in 1 .. 10 { do-something(i) }
+
+Như bạn có thể đoán, thụt lề 4 dấu cách. Nhân tiện, thay vì thụt lề khối, bạn có thể sử dụng các khối được phân cách, nếu bạn muốn:
+
+```
+define foobar() {
+    print "Chào mừng đến với flavor country!";
+}
+```
+
+(điều này làm cho sao chép & dán dễ dàng hơn). Bạn có thể tùy chọn đánh dấu khối được phân cách để Pandoc tô màu cú pháp:
+
+```python
+import time
+# Nhanh, đếm đến mười!
+for i in range(10):
+    # (nhưng không *quá* nhanh)
+    time.sleep(0.5)
+    print i
+```
+
+### Tiêu đề h3
+
+Bây giờ là danh sách lồng nhau:
+
+1. Đầu tiên, lấy những nguyên liệu này:
+
+    - cà rốt
+    - cần tây
+    - đậu lăng
+
+2. Đun sôi một ít nước.
+
+3. Đổ mọi thứ vào nồi và làm theo
+    thuật toán này:
+
+        tìm thìa gỗ
+        mở nắp nồi
+        khuấy
+        đậy nắp nồi
+        đặt thìa gỗ không cân bằng trên tay cầm nồi
+        đợi 10 phút
+        quay lại bước đầu tiên (hoặc tắt bếp khi xong)
+
+    Đừng chạm vào thìa gỗ nếu không nó sẽ rơi.
+
+Lưu ý lại cách văn bản luôn căn chỉnh trên thụt lề 4 dấu cách (bao gồm cả dòng cuối cùng tiếp tục mục 3 ở trên).
+
+Đây là liên kết đến [một trang web](http://foo.bar), đến [một tài liệu cục bộ](local-doc.html), và đến [một tiêu đề trong tài liệu hiện tại](#tiêu-đề-h2). Đây là một chú thích cuối trang [^1].
+
+[^1]: Nội dung chú thích ở đây.
+
+Bảng có thể trông như thế này:
+
+kích thước chất liệu màu sắc
+
+---
+
+9 da nâu
+10 vải canvas tự nhiên
+11 thủy tinh trong suốt
+
+Bảng: Giày, kích cỡ và chất liệu
+
+(Trên đây là chú thích cho bảng.) Pandoc cũng hỗ trợ
+bảng nhiều dòng:
+
+---
+
+từ khóa văn bản
+
+---
+
+đỏ Hoàng hôn, táo, và
+những thứ màu đỏ hoặc
+đỏ khác.
+
+xanh lá Lá, cỏ, ếch
+và những thứ khác không
+dễ dàng có màu xanh.
+
+---
+
+Một đường kẻ ngang sau đây.
+
+---
+
+Đây là danh sách định nghĩa:
+
+táo
+: Tốt để làm sốt táo.
+cam
+: Họ cam chanh!
+cà chua
+: Không có chữ "e" trong tomatoe.
+
+Lại một lần nữa, văn bản được thụt lề 4 dấu cách. (Đặt một dòng trống giữa mỗi cặp thuật ngữ/định nghĩa để dàn trải mọi thứ hơn.)
+
+Đây là một "khối dòng":
+
+| Dòng một
+| Dòng hai
+| Dòng ba
+
+và hình ảnh có thể được chỉ định như thế này:
+
+[//]: # (![hình ảnh ví dụ]&#40;./demo-banner.png "Một hình ảnh mẫu"&#41;)
+
+Phương trình toán nội dòng như thế này: $\omega = d\phi / dt$. Toán hiển thị nên được đặt trên dòng riêng và đặt trong dấu đô-la kép:
+
+$$I = \int \rho R^{2} dV$$
+
+$$
+\begin{equation*}
+\pi
+=3.1415926535
+ \;8979323846\;2643383279\;5028841971\;6939937510\;5820974944
+ \;5923078164\;0628620899\;8628034825\;3421170679\;\ldots
+\end{equation*}
+$$
+
+Và lưu ý rằng bạn có thể sử dụng dấu gạch chéo ngược để thoát bất kỳ ký tự dấu câu nào bạn muốn hiển thị nguyên văn, ví dụ: \`foo\`, \*bar\*, v.v.

--- a/src/content/posts/mulesoft-tutorial-part-1-vi.md
+++ b/src/content/posts/mulesoft-tutorial-part-1-vi.md
@@ -1,0 +1,137 @@
+---
+lang: vi
+title: Hướng dẫn MuleSoft cho mọi người (Phần 1)
+description: >-
+  Làm chủ MuleSoft với hướng dẫn thân thiện cho người mới bắt đầu! Tìm hiểu API integration, Anypoint Studio và nhiều hơn nữa—hoàn hảo cho nhà phát triển & sinh viên. Bắt đầu ngay!
+author: minhpt
+published: 2025-03-25
+category: Integration
+tags: [tutorial, mulesoft, low-code, integration, develope]
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mulesoft-tutorial-part-1.png
+---
+
+## Giới Thiệu về MuleSoft
+
+Chào mừng các nhà phát triển và sinh viên! Trong bối cảnh kỹ thuật số kết nối ngày nay, khả năng tích hợp các hệ thống và ứng dụng đa dạng là điều tối quan trọng. Nếu bạn đang muốn nâng cao kỹ năng và giải quyết các thách thức tích hợp phức tạp, MuleSoft là một nền tảng mạnh mẽ bạn nhất định nên khám phá. Bài đăng blog này sẽ giới thiệu về MuleSoft, lợi ích của nó và các ứng dụng thực tế.
+
+### MuleSoft là gì?
+
+MuleSoft, một công ty của Salesforce, cung cấp nền tảng tích hợp có tên Anypoint Platform. Về cốt lõi, MuleSoft đơn giản hóa quy trình kết nối các ứng dụng, dữ liệu và thiết bị, bất kể chúng ở đâu. Nó cho phép tạo các Giao diện Lập trình Ứng dụng (API) và luồng tích hợp, cho phép các hệ thống giao tiếp liền mạch.
+
+Cách tiếp cận của MuleSoft tập trung vào API, thúc đẩy kiến trúc mô-đun và có thể tái sử dụng. Cách tiếp cận kết nối dẫn đầu bằng API này phá vỡ các silo và tạo điều kiện cho luồng thông tin trong toàn tổ chức. Thay vì các kết nối điểm-điểm, có thể trở nên phức tạp và khó quản lý, MuleSoft khuyến khích xây dựng một mạng lưới các API có thể tái sử dụng.
+
+### Tại sao nên học MuleSoft? Lợi ích cho nhà phát triển và sinh viên
+
+Học MuleSoft mang lại nhiều lợi thế cho cả nhà phát triển và sinh viên:
+
+* **Nhu cầu Cao:** Kỹ năng tích hợp được săn đón nhiều trong ngành CNTT. Chuyên môn về MuleSoft có thể mở ra nhiều cơ hội nghề nghiệp.
+* **Tính Linh hoạt:** MuleSoft có thể được sử dụng để tích hợp nhiều loại hệ thống, từ ứng dụng kế thừa đến dịch vụ đám mây hiện đại.
+* **Kết nối Dẫn đầu bằng API:** Hiểu về kết nối dẫn đầu bằng API là rất quan trọng trong thế giới tập trung vào API ngày nay. MuleSoft cung cấp một cách thực tế để học và triển khai cách tiếp cận này.
+* **Tích hợp Đơn giản hóa:** Giao diện đồ họa và các connector dựng sẵn của MuleSoft hợp lý hóa quy trình tích hợp, giảm thời gian phát triển.
+* **Khả năng Mở rộng và Độ tin cậy:** Anypoint Platform của MuleSoft được thiết kế cho khả năng mở rộng và độ tin cậy, đảm bảo các tích hợp có thể xử lý khối lượng dữ liệu và lưu lượng truy cập ngày càng tăng.
+* **Tích hợp Đám mây và Tại chỗ:** MuleSoft hỗ trợ tích hợp lai, cho phép bạn kết nối cả hệ thống đám mây và tại chỗ.
+* **Dành cho Sinh viên:** Học MuleSoft cung cấp kinh nghiệm thực tế trong tích hợp doanh nghiệp, bổ sung cho việc học thuật. Nó giúp hiểu được các thách thức tích hợp trong thế giới thực.
+
+### Tổng quan về MuleSoft Anypoint Platform
+
+MuleSoft Anypoint Platform là một bộ công cụ toàn diện để xây dựng và quản lý tích hợp. Các thành phần chính bao gồm:
+
+* **Anypoint Design Center:** IDE dựa trên web để thiết kế và xây dựng API và tích hợp.
+* **Anypoint Exchange:** Kho lưu trữ để chia sẻ và khám phá API, connector và mẫu.
+* **Anypoint Runtime Manager:** Bảng điều khiển quản lý để triển khai và giám sát các ứng dụng Mule.
+* **Anypoint API Manager:** Công cụ quản lý và bảo mật API.
+* **Anypoint Connectors:** Connector dựng sẵn cho các ứng dụng và dịch vụ phổ biến, như Salesforce, SAP và cơ sở dữ liệu.
+* **Mule Runtime Engine:** Môi trường thực thi để chạy các ứng dụng Mule.
+* **DataWeave:** Ngôn ngữ chuyển đổi dữ liệu mạnh mẽ để thao tác dữ liệu trong tích hợp.
+
+Các công cụ thiết kế trực quan và thành phần dựng sẵn của nền tảng giúp việc phát triển và triển khai tích hợp dễ dàng hơn, giảm nhu cầu viết mã rộng rãi.
+
+### Các trường hợp sử dụng MuleSoft trong ứng dụng thực tế
+
+MuleSoft được sử dụng trong nhiều ngành công nghiệp để giải quyết các thách thức tích hợp phức tạp. Dưới đây là một vài ví dụ:
+
+* **Bán lẻ:** Tích hợp nền tảng thương mại điện tử, hệ thống quản lý hàng tồn kho và hệ thống quản lý quan hệ khách hàng (CRM) để cung cấp trải nghiệm khách hàng liền mạch.
+* **Dịch vụ Tài chính:** Kết nối hệ thống ngân hàng cốt lõi, cổng thanh toán và hệ thống phát hiện gian lận để cho phép giao dịch an toàn và hiệu quả.
+* **Chăm sóc Sức khỏe:** Tích hợp hồ sơ sức khỏe điện tử (EHRs), cổng thông tin bệnh nhân và thiết bị y tế để cải thiện chăm sóc bệnh nhân và chia sẻ dữ liệu.
+* **Sản xuất:** Kết nối hệ thống chuỗi cung ứng, hệ thống sản xuất và hệ thống kiểm soát chất lượng để tối ưu hóa hoạt động và cải thiện hiệu quả.
+* **Chính phủ:** Tích hợp các dịch vụ công và cơ sở dữ liệu khác nhau để cải thiện quyền truy cập của công dân và hợp lý hóa quy trình.
+* **Viễn thông:** Tích hợp hệ thống thanh toán, hệ thống quản lý mạng và hệ thống dịch vụ khách hàng để cung cấp dịch vụ liền mạch.
+
+Bằng cách triển khai MuleSoft, các tổ chức có thể đạt được:
+
+* Tăng tính linh hoạt và thời gian đưa ra thị trường nhanh hơn.
+* Cải thiện khả năng hiển thị và khả năng truy cập dữ liệu.
+* Nâng cao trải nghiệm khách hàng.
+* Giảm chi phí vận hành.
+
+Nếu bạn là nhà phát triển hoặc sinh viên muốn mở rộng kỹ năng tích hợp, MuleSoft là một nền tảng đáng giá để học. Cách tiếp cận dẫn đầu bằng API và bộ công cụ toàn diện có thể giúp bạn giải quyết các thách thức tích hợp phức tạp và xây dựng các giải pháp mạnh mẽ, có khả năng mở rộng. Hãy bắt đầu khám phá MuleSoft ngay hôm nay và mở khóa sức mạnh của kết nối liền mạch.
+
+## Thiết Lập Môi Trường Phát Triển MuleSoft: Hướng Dẫn Cho Nhà Phát Triển
+
+### Hướng dẫn từng bước cài đặt MuleSoft Anypoint Studio
+
+Anypoint Studio là môi trường phát triển tích hợp (IDE) để xây dựng các ứng dụng Mule. Đây là cách cài đặt nó:
+
+1. **Tải xuống Anypoint Studio:**
+    * Truy cập trang web MuleSoft và tải xuống phiên bản Anypoint Studio mới nhất. Bạn sẽ cần một tài khoản MuleSoft (miễn phí để tạo).
+    * Chọn trình cài đặt phù hợp cho hệ điều hành của bạn (Windows, macOS hoặc Linux).
+
+2. **Cài đặt Bộ Phát triển Java (JDK):**
+    * MuleSoft yêu cầu một JDK tương thích. Đảm bảo bạn đã cài đặt phiên bản gần đây. Oracle JDK hoặc OpenJDK được khuyến nghị.
+    * Đặt biến môi trường `JAVA_HOME` trỏ đến thư mục cài đặt JDK của bạn.
+
+3. **Chạy Trình Cài đặt:**
+    * Thực thi trình cài đặt đã tải xuống.
+    * Làm theo hướng dẫn trên màn hình để hoàn tất cài đặt.
+    * Chọn thư mục cài đặt.
+
+4. **Khởi chạy Anypoint Studio:**
+    * Sau khi cài đặt, khởi chạy Anypoint Studio.
+    * Bạn sẽ được nhắc chọn một thư mục workspace nơi các dự án của bạn sẽ được lưu trữ.
+
+5. **Cài đặt Mule Runtime:**
+    * Khi bạn tạo một dự án mới, studio sẽ yêu cầu cài đặt mule runtime. Runtime này cần thiết để kiểm tra và chạy ứng dụng mule của bạn.
+
+### Yêu cầu hệ thống cho phát triển MuleSoft
+
+Để đảm bảo trải nghiệm phát triển suôn sẻ, hệ thống của bạn nên đáp ứng các yêu cầu sau:
+
+* **Hệ điều hành:** Windows 10 trở lên, macOS 10.15 trở lên hoặc bản phân phối Linux được hỗ trợ.
+* **JDK:** JDK tương thích (ví dụ: Oracle JDK 8 hoặc 11, OpenJDK 8 hoặc 11).
+* **RAM:** Khuyến nghị ít nhất 8 GB RAM.
+* **Dung lượng Đĩa:** Đủ dung lượng đĩa cho Anypoint Studio, JDK và các tệp dự án.
+* **Kết nối Internet:** Cần thiết để tải xuống các phụ thuộc và truy cập tài nguyên trực tuyến.
+
+### Cấu hình MuleSoft Anypoint Platform
+
+Sau khi cài đặt Anypoint Studio, bạn sẽ cần cấu hình nó để kết nối với Anypoint Platform:
+
+1. **Tạo Tài khoản MuleSoft:** Nếu bạn chưa có, hãy tạo một tài khoản MuleSoft miễn phí trên trang web Anypoint Platform.
+2. **Thông tin Đăng nhập Anypoint Platform:**
+    * Bạn sẽ cần tên người dùng và mật khẩu Anypoint Platform để kết nối Studio.
+3. **Kết nối Studio với Anypoint Platform:**
+    * Bên trong Anypoint Studio, bạn có thể thêm tài khoản Anypoint platform của mình, điều này cho phép bạn xuất bản và tiêu thụ API từ Anypoint Exchange.
+    * Kết nối này sẽ cho phép bạn triển khai và quản lý các ứng dụng của mình.
+
+### Tổng quan về Connector và Công cụ MuleSoft
+
+MuleSoft cung cấp một hệ sinh thái phong phú các connector và công cụ để đơn giản hóa việc phát triển tích hợp:
+
+* **Anypoint Connectors:**
+  * Connector dựng sẵn cho nhiều ứng dụng và dịch vụ khác nhau, như Salesforce, cơ sở dữ liệu, API và hệ thống nhắn tin.
+  * Các connector này hợp lý hóa tích hợp bằng cách xử lý các giao thức truyền thông cơ bản.
+* **DataWeave:**
+  * Ngôn ngữ chuyển đổi dữ liệu mạnh mẽ để thao tác dữ liệu trong các luồng Mule.
+  * Nó cho phép bạn chuyển đổi dữ liệu giữa các định dạng và cấu trúc khác nhau.
+* **Mule Runtime Engine:**
+  * Môi trường thực thi để chạy các ứng dụng Mule.
+  * Nó xử lý việc triển khai, thực thi và giám sát các tích hợp của bạn.
+* **Anypoint Exchange:**
+  * Kho lưu trữ để khám phá và chia sẻ API, connector và mẫu.
+  * Nó thúc đẩy khả năng tái sử dụng và tăng tốc phát triển.
+* **Anypoint Design Center:**
+  * IDE dựa trên web để thiết kế API và luồng Mule.
+
+Bằng cách làm chủ các công cụ và connector này, bạn có thể xây dựng các tích hợp mạnh mẽ và có khả năng mở rộng với MuleSoft.
+
+Thiết lập môi trường phát triển MuleSoft của bạn là bước đầu tiên để mở khóa sức mạnh của tích hợp. Với Anypoint Studio và Anypoint Platform, bạn sẽ có các công cụ cần thiết để giải quyết các thách thức tích hợp phức tạp. Chúc bạn code vui vẻ!

--- a/src/content/posts/mulesoft-tutorial-session-1-vi.md
+++ b/src/content/posts/mulesoft-tutorial-session-1-vi.md
@@ -1,0 +1,202 @@
+---
+lang: vi
+title: "Hướng dẫn MuleSoft cho Người Mới Bắt Đầu [Phần 1]: Từ Mớ Hỗn Độn Spaghetti Đến Tích Hợp Hiện Đại (ESB, API Gateway & MuleSoft Được Giải Thích)"
+published: 2025-03-25
+category: Integration
+tags: [MuleSoft, MuleSoft Tutorial, ESB, Enterprise Service Bus, API Gateway, Integration, Middleware, Anypoint Platform, API Management, Beginner]
+author: minhpt
+mermaid: true
+description: "Bắt đầu hành trình MuleSoft của bạn! Hiểu về thách thức tích hợp (kiến trúc spaghetti), sự trỗi dậy của ESB và API Gateway, và vị trí của MuleSoft. Hoàn hảo cho người mới bắt đầu."
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/MuleSoft%20Tutorial%20For%20Beginners.png
+---
+
+Xin chào mọi người, và chào mừng đến với bài đăng đầu tiên trong loạt hướng dẫn MuleSoft của chúng tôi! Là một nhà phát triển MuleSoft cấp cao, tôi thường thấy các công ty gặp khó khăn với việc kết nối số lượng ứng dụng ngày càng tăng của họ. Nếu bạn mới làm quen với tích hợp hoặc tò mò về MuleSoft, bạn đã đến đúng nơi. Hãy bắt đầu với một câu chuyện quen thuộc.
+
+## Nỗi Đau Lớn Lên: Cơn Đau Đầu Tích Hợp của Acme Corp
+
+Hãy tưởng tượng một công ty, chúng ta hãy gọi nó là "Acme Corp". Họ bắt đầu nhỏ, có thể chỉ với một hệ thống tồn kho và một cửa hàng trực tuyến đơn giản. Cuộc sống thật tốt đẹp. Nhưng khi Acme lớn lên, họ thêm nhiều phần mềm hơn: CRM cho bán hàng, ERP cho tài chính, hệ thống HR riêng, có thể là ứng dụng di động... nghe quen không?
+
+Mỗi lần có hệ thống mới, họ cần nó giao tiếp với các hệ thống khác. "Chúng tôi cần dữ liệu khách hàng từ CRM trong ERP!" hoặc "Đồng bộ tồn kho từ ERP đến cửa hàng trực tuyến!" Vì vậy, các nhà phát triển đã làm điều có vẻ hợp lý: họ xây dựng các kết nối trực tiếp. CRM nói chuyện với ERP. ERP nói chuyện với cửa hàng. Cửa hàng nói chuyện với hệ thống tồn kho. Ứng dụng di động nói chuyện với *mọi thứ*.
+
+Ban đầu, **tích hợp điểm-điểm** này hoạt động. Nhưng chẳng bao lâu, bức tranh CNTT của Acme trông như thế này:
+
+```mermaid
+graph TD
+    subgraph Ví Dụ Kiến Trúc Spaghetti
+
+        %% Định nghĩa các hệ thống (nút)
+        CRM[Hệ thống CRM]
+        ERP[Hệ thống ERP]
+        WebStore[Cửa hàng Trực tuyến]
+        HR[Hệ thống HR]
+        MobileApp[Ứng dụng Di động]
+        Inventory[Quản lý Tồn kho]
+        Reporting[Cơ sở dữ liệu Báo cáo]
+
+        %% Định nghĩa các kết nối rối rắm (cạnh)
+        CRM --- ERP
+        ERP --- WebStore
+        WebStore --- Inventory
+        HR --- ERP
+        MobileApp --- CRM
+        MobileApp --- ERP
+        MobileApp --- WebStore
+        WebStore --- CRM
+        ERP --- Inventory
+        Inventory --- ERP
+        CRM --- MobileApp
+        ERP --- HR
+        Inventory --- WebStore
+        WebStore --- ERP
+        HR --- CRM
+        Reporting --- ERP
+        Reporting --- CRM
+        WebStore --- Reporting
+        Inventory --- MobileApp
+        ERP --- MobileApp
+
+    end
+```
+
+Đây, các bạn của tôi, được gọi một cách trìu mến (hoặc bực bội) là **Kiến trúc Spaghetti**.
+
+### Tại Sao Kiến Trúc Spaghetti Gây Khó Tiêu
+
+Mặc dù các kết nối trực tiếp có vẻ đơn giản lúc đầu, cách tiếp cận này nhanh chóng trở thành cơn ác mộng:
+
+* **Độ phức tạp:** Mỗi hệ thống mới có khả năng yêu cầu kết nối đến nhiều hệ thống hiện có. Số lượng kết nối bùng nổ! Việc quản lý và hiểu mạng lưới này trở nên cực kỳ khó khăn.
+* **Dễ vỡ:** Nếu một hệ thống thay đổi định dạng dữ liệu hoặc API, *tất cả các hệ thống* kết nối trực tiếp với nó đều cần sửa đổi. Một thay đổi nhỏ có thể gây ra một loạt lỗi. Bảo trì rất tốn kém và chậm chạp.
+* **Khả năng tái sử dụng kém:** Logic để kết nối với một hệ thống cụ thể (ví dụ: lấy dữ liệu khách hàng) có thể bị trùng lặp ở nhiều nơi.
+* **Khó mở rộng:** Thêm hệ thống mới hoặc mở rộng hệ thống hiện có trở thành một dự án lớn liên quan đến việc gỡ rối và kết nối lại.
+* **Thiếu khả năng quan sát:** Hiểu luồng dữ liệu trên toàn tổ chức gần như không thể. Gỡ lỗi giống như tìm một sợi mì cụ thể trong tô spaghetti.
+
+Acme Corp nhận ra họ cần một cách tốt hơn. Họ cần **phần mềm trung gian**.
+
+## Sự Xuất Hiện của Người Điều Khiển Giao Thông: Enterprise Service Bus (ESB)
+
+Để giải quyết mớ hỗn độn spaghetti, khái niệm **Enterprise Service Bus (ESB)** đã xuất hiện. Hãy nghĩ về ESB như một xương sống giao tiếp trung tâm hoặc một "bus" phần mềm trung gian mà các ứng dụng cắm vào, thay vì nói chuyện trực tiếp với nhau.
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/esb-diagram.png)
+
+### Khái Niệm ESB
+
+* **Trung gian:** ESB có thể chuyển đổi định dạng dữ liệu giữa các hệ thống khác nhau (ví dụ: XML sang JSON).
+* **Định tuyến:** Nó hướng thông điệp từ hệ thống nguồn đến đúng hệ thống đích.
+* **Chuyển đổi Giao thức:** Nó có thể xử lý giao tiếp giữa các hệ thống sử dụng các giao thức khác nhau (ví dụ: HTTP sang JMS).
+* **Tập trung hóa:** Cung cấp một điểm duy nhất để quản lý và giám sát tích hợp.
+
+### Điểm Mạnh của ESB
+
+* **Tách rời:** Các hệ thống không cần biết chi tiết cụ thể (vị trí, giao thức, định dạng dữ liệu) của các hệ thống khác. Chúng chỉ nói chuyện với ESB.
+* **Khả năng tái sử dụng:** Logic tích hợp chung (như chuyển đổi dữ liệu hoặc xác thực) thường có thể được xây dựng trong ESB và tái sử dụng.
+* **Cải thiện khả năng bảo trì:** Các thay đổi trong một hệ thống ít khả năng ảnh hưởng đến các hệ thống khác, vì ESB xử lý việc trung gian.
+
+### Điểm Yếu của ESB
+
+* **Nút thắt tiềm ẩn:** Nếu không được thiết kế đúng, ESB trung tâm có thể trở thành nút thắt hiệu suất.
+* **Độ phức tạp:** Việc triển khai và quản lý một ESB giàu tính năng có thể phức tạp.
+* **Khóa nhà cung cấp:** ESB truyền thống đôi khi có thể dẫn đến phụ thuộc vào công nghệ của một nhà cung cấp cụ thể.
+* **Không phải lúc nào cũng tập trung vào API:** Mặc dù ESB có thể expose các dịch vụ, trọng tâm chính của chúng thường là tích hợp hệ thống nội bộ, không nhất thiết là quản lý các API hiện đại hướng ra bên ngoài.
+
+## Người Gác Cổng: API Gateway
+
+Khi API (Giao diện Lập trình Ứng dụng) trở thành tiêu chuẩn cho các ứng dụng giao tiếp, đặc biệt qua web và di động, một phần mềm trung gian khác đã nổi lên: **API Gateway**.
+
+Hãy nghĩ về API Gateway như một điểm vào chuyên biệt *dành riêng cho việc quản lý API*. Nó nằm phía trước các dịch vụ backend hoặc API của bạn và hoạt động như người gác cổng và quản lý lưu lượng cho khách hàng bên ngoài (và đôi khi nội bộ).
+
+```mermaid
+graph TD
+    subgraph Ví Dụ Kiến Trúc API Gateway
+
+        %% Định nghĩa các Client ở trên cùng
+        ClientWeb[Ứng dụng Web]
+        ClientMobile[Ứng dụng Di động]
+        ClientPartner[Hệ thống Đối tác / B2B]
+
+        %% Định nghĩa API Gateway ở giữa
+        APIGateway[API Gateway]
+
+        %% Định nghĩa Backend Microservices hoặc API ở dưới cùng
+        ServiceUsers[API / Dịch vụ Người dùng]
+        ServiceOrders[API / Dịch vụ Đơn hàng]
+        ServiceProducts[API / Dịch vụ Sản phẩm]
+        ServiceInventory[API / Dịch vụ Tồn kho]
+
+        %% Kết nối: Các Client kết nối đến Gateway
+        ClientWeb --> APIGateway
+        ClientMobile --> APIGateway
+        ClientPartner --> APIGateway
+
+        %% Kết nối: Gateway định tuyến yêu cầu đến Backend Services
+        APIGateway --> ServiceUsers
+        APIGateway --> ServiceOrders
+        APIGateway --> ServiceProducts
+        APIGateway --> ServiceInventory
+
+    end
+```
+
+### Khái Niệm API Gateway
+
+* **Expose API:** Trình bày các dịch vụ backend dưới dạng API được quản lý.
+* **Thực thi Bảo mật:** Xử lý xác thực, phân quyền, giới hạn tốc độ và các chính sách bảo mật khác.
+* **Quản lý Lưu lượng:** Cân bằng tải, chuyển đổi yêu cầu/phản hồi, lưu cache.
+* **Giám sát & Phân tích:** Thu thập nhật ký và số liệu về việc sử dụng API.
+
+### ESB so với API Gateway: Sự Khác Biệt Là Gì?
+
+Mặc dù có sự chồng chéo, trọng tâm của chúng khác nhau:
+
+* **ESB:** Chủ yếu tập trung vào **tích hợp các hệ thống nội bộ đa dạng** sử dụng nhiều giao thức và định dạng dữ liệu. Thường liên quan đến điều phối phức tạp và logic trung gian *bên trong* bus. Hãy nghĩ: Xương sống tích hợp Hệ thống-đến-Hệ thống.
+* **API Gateway:** Chủ yếu tập trung vào **quản lý, bảo mật và expose API** (thường là REST hoặc SOAP) cho người tiêu dùng bên ngoài hoặc nội bộ. Hoạt động như một mặt tiền hoặc proxy ngược cho các dịch vụ backend. Hãy nghĩ: Bộ điều khiển lưu lượng API và nhân viên bảo vệ.
+
+Một công cụ có thể làm cả hai không? Có, các nền tảng tích hợp hiện đại thường làm mờ ranh giới.
+
+## Chọn Công Cụ Của Bạn: Bối Cảnh ESB so với API Gateway
+
+Khi nào bạn sử dụng cái nào?
+
+* **Cân nhắc cách tiếp cận ESB khi:** Thách thức chính của bạn là tích hợp nhiều hệ thống nội bộ kế thừa hoặc đa dạng với các giao thức khác nhau và nhu cầu định tuyến/chuyển đổi phức tạp.
+* **Cân nhắc API Gateway khi:** Mục tiêu chính của bạn là expose các dịch vụ backend dưới dạng API được quản lý, bảo mật chúng, xử lý lưu lượng từ khách hàng web/di động và có được thông tin chi tiết về việc sử dụng API.
+
+**Lưu ý Quan trọng:** Nhiều nền tảng hiện đại cung cấp khả năng bao trùm cả hai lĩnh vực.
+
+## Giới Thiệu MuleSoft: Nền Tảng Tích Hợp Thống Nhất
+
+Vậy, **MuleSoft** phù hợp ở đâu?
+
+**MuleSoft là gì?**
+
+MuleSoft, hiện là một phần của Salesforce, cung cấp **Anypoint Platform**, một **nền tảng tích hợp thống nhất** hàng đầu. Nó được thiết kế để kết nối *bất kỳ* ứng dụng, nguồn dữ liệu hoặc thiết bị nào, dù trên đám mây hay tại chỗ.
+
+**MuleSoft hoạt động như thế nào?**
+
+MuleSoft kết hợp khả năng của cả ESB truyền thống và API Gateway hiện đại, được xây dựng trên khái niệm **kết nối dẫn đầu bằng API**. Thay vì chỉ điểm-điểm hoặc một ESB nguyên khối, MuleSoft khuyến khích xây dựng các API có thể tái sử dụng để mở khóa dữ liệu và khả năng trên toàn tổ chức.
+
+Nó hoạt động như:
+
+* **ESB:** Để tích hợp hệ thống nội bộ phức tạp, chuyển đổi dữ liệu (sử dụng ngôn ngữ DataWeave mạnh mẽ của nó) và kết nối hệ thống kế thừa.
+* **API Gateway:** Để thiết kế, xây dựng, bảo mật, quản lý và phân tích API.
+
+**Các Thành phần Chính (Nhìn Nhanh):**
+
+* **Anypoint Platform:** Giao diện web thống nhất để quản lý mọi thứ.
+* **Anypoint Studio:** IDE trên máy tính để bàn để thiết kế và xây dựng tích hợp (ứng dụng Mule).
+* **Mule Runtime Engine:** Engine nhẹ chạy các ứng dụng Mule của bạn.
+* **Connectors:** Connector dựng sẵn cho hàng trăm hệ thống và giao thức (cơ sở dữ liệu, ứng dụng SaaS, hàng đợi thông điệp, v.v.).
+* **API Manager:** Quản trị và bảo mật API của bạn.
+* **Anypoint Exchange:** Một thị trường để khám phá và chia sẻ các tài sản có thể tái sử dụng như API và connector.
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mulesoft-lifecycle.png)
+
+Mục tiêu của MuleSoft là làm cho tích hợp dễ dàng hơn và nhanh hơn, chuyển từ các kết nối dễ vỡ sang một mạng lưới linh hoạt các API có thể tái sử dụng.
+
+## Tổng Kết Phần 1
+
+Chúng ta đã đi từ sự hỗn loạn của kiến trúc spaghetti, qua các cách tiếp cận có cấu trúc của ESB và API Gateway, và đến tầm nhìn thống nhất của MuleSoft về tích hợp. Hiểu được sự phát triển này là chìa khóa để đánh giá cao *lý do* tại sao MuleSoft lại là một công cụ mạnh mẽ trong thế giới kết nối ngày nay.
+
+Trong bài đăng tiếp theo, chúng ta sẽ thực hành! Chúng tôi sẽ đề cập đến **Thiết lập Môi Trường Phát Triển MuleSoft của Bạn**, bao gồm cài đặt Anypoint Studio.
+
+**Có câu hỏi? Suy nghĩ? Hãy chia sẻ trong phần bình luận bên dưới!** Những thách thức tích hợp lớn nhất bạn đã gặp phải là gì?
+
+---

--- a/src/content/posts/mulesoft-tutorial-session-2-vi.md
+++ b/src/content/posts/mulesoft-tutorial-session-2-vi.md
@@ -1,0 +1,97 @@
+---
+lang: vi
+title: "Hướng dẫn MuleSoft [Phần 2]: Thiết Lập Môi Trường Phát Triển Anypoint Studio"
+published: 2025-03-25
+category: Integration
+tags: [MuleSoft, MuleSoft Tutorial, Anypoint Studio, Install MuleSoft, Development Environment, JDK, Workspace, Anypoint Platform, Beginner, MuleSoft Guide]
+author: minhpt
+description: "Bước đầu tiên để chinh phục MuleSoft! Hướng dẫn chi tiết về kiểm tra yêu cầu hệ thống, cài đặt Anypoint Studio, khám phá giao diện và kết nối với Anypoint Platform. Dành cho người mới bắt đầu."
+
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/MuleSoft%20Tutorial%20For%20Beginners.png
+---
+Chào mừng trở lại với loạt hướng dẫn MuleSoft dành cho người mới bắt đầu!
+
+Trong [Phần 1](https://minixium.com/posts/mulesoft-tutorial-session-1/), chúng ta đã khám phá thế giới tích hợp, sự trỗi dậy của ESB, API Gateway và vị trí của MuleSoft trong bối cảnh đó. Bây giờ là lúc chuẩn bị "công cụ" để bắt đầu thực hành – thiết lập môi trường phát triển! Đây là một bước quan trọng, giống như chuẩn bị bếp trước khi nấu một bữa ăn ngon.
+
+Trong phần này, chúng ta sẽ tập trung vào **Anypoint Studio**, IDE (Môi trường Phát triển Tích hợp) chính thức và mạnh mẽ nhất để xây dựng các ứng dụng Mule. Hãy bắt đầu!
+
+## 1. Kiểm Tra "Sức Khỏe" Máy Tính Của Bạn (Yêu Cầu Hệ Thống)
+
+Trước khi cài đặt, hãy đảm bảo máy tính của bạn đáp ứng các yêu cầu tối thiểu để Anypoint Studio chạy mượt mà:
+
+* **Hệ điều hành (OS):** Windows 10 trở lên, macOS 10.15 (Catalina) trở lên hoặc các bản phân phối Linux phổ biến được hỗ trợ (như Ubuntu, RHEL).
+* **Bộ Phát triển Java (JDK):** Điều này là **bắt buộc**. Anypoint Studio cần một phiên bản JDK tương thích (thường là JDK 8 hoặc JDK 11 - kiểm tra phiên bản Studio cụ thể bạn tải xuống để biết yêu cầu chính xác). Oracle JDK hoặc OpenJDK đều tốt.
+* **Quan trọng:** Đừng quên đặt biến môi trường `JAVA_HOME` trỏ đến thư mục cài đặt JDK của bạn.
+* **RAM:** Khuyến nghị ít nhất 8GB RAM; 16GB thậm chí tốt hơn cho việc chạy các ứng dụng phức tạp hơn.
+* **Dung lượng Đĩa:** Cần đủ dung lượng trống cho Anypoint Studio, JDK, Mule Runtime và các dự án của bạn (khoảng vài GB).
+* **Kết nối Internet:** Cần thiết để tải xuống Studio, các phụ thuộc và kết nối với Anypoint Platform.
+
+## 2. Cài Đặt Anypoint Studio - Ngôi Nhà Của Các Nhà Phát Triển MuleSoft
+
+Bây giờ là phần chính - cài đặt Anypoint Studio!
+
+1. **Tải xuống Anypoint Studio:**
+    * Truy cập trang tải xuống chính thức của MuleSoft ([MuleSoft Anypoint Studio Download](https://www.mulesoft.com/platform/studio) - liên kết có thể thay đổi, hãy tìm kiếm "Download Anypoint Studio").
+    * Bạn sẽ cần đăng nhập bằng tài khoản MuleSoft (bạn có thể tạo một tài khoản miễn phí).
+    * Chọn phiên bản phù hợp với hệ điều hành của bạn (Windows, macOS, Linux) và tải xuống tệp cài đặt.
+
+2. **Tiến Hành Cài Đặt:**
+    * **Windows:** Chạy tệp `.exe` đã tải xuống và làm theo hướng dẫn của trình hướng dẫn thiết lập. Thường chỉ là Next, Next, Finish!
+    * **macOS:** Mở tệp `.dmg` và kéo biểu tượng Anypoint Studio vào thư mục Applications.
+    * **Linux:** Giải nén tệp `.tar.gz` vào thư mục bạn muốn.
+    * Chọn thư mục cài đặt nếu được yêu cầu.
+
+3. **Khởi chạy và Chọn Workspace:**
+    * Sau khi cài đặt, khởi chạy Anypoint Studio.
+    * Lần đầu tiên khởi chạy, Studio sẽ yêu cầu bạn chọn một **Workspace**. Đây là một thư mục trên máy tính của bạn nơi lưu trữ tất cả các dự án Mule và cài đặt liên quan. Chọn một vị trí dễ nhớ và quản lý.
+
+## 3. Cài Đặt Mule Runtime Engine - "Trái Tim" Của Ứng Dụng Mule
+
+Khi bạn tạo một dự án Mule mới trong Anypoint Studio, Studio thường sẽ đề xuất hoặc yêu cầu bạn cài đặt một phiên bản cụ thể của **Mule Runtime Engine**. Đây là môi trường thực thi sẽ chạy ứng dụng Mule của bạn.
+
+* Làm theo hướng dẫn của Studio để cài đặt phiên bản Runtime cần thiết. Quy trình này thường tự động và chỉ cần kết nối internet.
+
+## 4. Khám Phá "Ngôi Nhà" Anypoint Studio
+
+Giao diện Anypoint Studio ban đầu có vẻ hơi choáng ngợp, nhưng đừng lo, chúng ta sẽ làm quen với các khu vực chính:
+
+* **Package Explorer:** Bên trái, hiển thị cấu trúc thư mục của dự án Mule của bạn (tương tự các IDE khác).
+* **Mule Palette:** Bên phải, chứa tất cả các "khối xây dựng" (thành phần, connector) để bạn kéo và thả xây dựng luồng. Đây là nơi bạn sẽ tìm thấy HTTP Listener, Set Payload, Logger, Database Connector, v.v.
+* **Canvas:** Khu vực trung tâm lớn nhất, nơi bạn "vẽ" các luồng của mình bằng cách kéo các thành phần từ Palette và kết nối chúng.
+* **Console:** Ở phía dưới, hiển thị nhật ký khi bạn chạy hoặc gỡ lỗi ứng dụng, bao gồm đầu ra từ thành phần Logger và thông báo lỗi.
+* **Properties View:** Thường nằm trong cùng khu vực với Console, hiển thị các tùy chọn cấu hình chi tiết cho thành phần hiện được chọn trên Canvas.
+* **Mule Debugger Perspective:** Một "chế độ xem" khác trong Studio, được kích hoạt khi bạn chạy ứng dụng ở chế độ Debug, giúp bạn theo dõi và kiểm tra giá trị của thông điệp và biến tại các điểm dừng.
+
+* **Demo Nhanh:** Hãy thử tạo một dự án Mule mới (`File > New > Mule Project`) để xem cấu trúc cơ bản và làm quen với các khu vực này. Chưa cần code phức tạp!
+
+## 5. Kết Nối Với "Trung Tâm Chỉ Huy" - Anypoint Platform
+
+Để tận dụng toàn bộ sức mạnh của MuleSoft, đặc biệt là để triển khai và quản lý API, bạn cần kết nối Anypoint Studio với tài khoản Anypoint Platform của mình.
+
+1. **Tài khoản Anypoint Platform:** Nếu bạn chưa có, hãy truy cập [https://anypoint.mulesoft.com](https://anypoint.mulesoft.com) và đăng ký tài khoản miễn phí.
+2. **Cấu hình trong Studio:**
+    * Vào menu `Window` (trên Windows/Linux) hoặc `Anypoint Studio` menu (trên macOS) -> `Preferences`.
+    * Điều hướng đến `Anypoint Studio` -> `Authentication`.
+    * Nhấp vào nút `Add...` và nhập tên người dùng/mật khẩu cho tài khoản Anypoint Platform bạn vừa tạo/đăng nhập.
+    * Nhấp `Apply and Close`.
+
+Vậy là xong! Studio của bạn bây giờ có thể "nói chuyện" với Anypoint Platform.
+
+## Thời Gian Thực Hành
+
+Cách tốt nhất để học là thực hành. Hãy dành thời gian để:
+
+* Cài đặt Anypoint Studio trên máy của bạn.
+* Tạo một dự án mới.
+* Thử kéo một vài thành phần từ Mule Palette lên Canvas.
+* Kết nối Studio với tài khoản Anypoint Platform của bạn.
+
+Nếu bạn gặp bất kỳ vấn đề nào, đừng ngần ngại xem lại các bước hoặc để lại bình luận!
+
+## Video
+
+{% include embed/youtube.html id='fI1p-OluQBA' %}
+
+---
+
+Trong phần tiếp theo (Module 3), chúng ta sẽ đi sâu vào các khái niệm cốt lõi như Mule Event, Flow, Subflow và Connectors. Hãy đảm bảo môi trường của bạn đã sẵn sàng! Hẹn gặp lại!

--- a/src/content/posts/open-source-alternatives-to-popular-saas-tools-vi.md
+++ b/src/content/posts/open-source-alternatives-to-popular-saas-tools-vi.md
@@ -1,0 +1,146 @@
+---
+lang: vi
+title: >- 
+  Các Giải Pháp Thay Thế Mã Nguồn Mở Cho Công Cụ SaaS Phổ Biến: Hướng Dẫn Toàn Diện (Phần 2) 🧑‍💻
+description: >-
+  Khám phá các giải pháp thay thế mã nguồn mở hàng đầu cho các công cụ SaaS phổ biến như Webflow, Firebase và Notion. Tiết kiệm chi phí, đảm bảo quyền riêng tư dữ liệu và tùy chỉnh tự do với Webstudio, Pocketbase, Rowy và nhiều hơn nữa!
+author: minhpt
+published: 2025-03-25
+category: Self-hosted
+tags: [open-source alternatives, SaaS tools, Webstudio, Pocketbase, Rowy, Notesnook, Outline, Sonic, Uptime Kuma, open-source software, self-hosted tools, cost-effective solutions, data privacy, open-source apps]
+---
+
+Trong thời đại kỹ thuật số ngày nay, các giải pháp Phần mềm dưới dạng Dịch vụ (SaaS) thống trị thị trường. Tuy nhiên, nhiều dịch vụ này đi kèm với chi phí định kỳ, lo ngại về quyền riêng tư và khả năng tùy chỉnh hạn chế. Điều gì sẽ xảy ra nếu bạn có thể thay thế các công cụ SaaS này bằng các giải pháp thay thế mã nguồn mở mà bạn có thể tự lưu trữ bằng Docker? Bạn không chỉ tiết kiệm tiền mà còn giành được toàn quyền kiểm soát dữ liệu và cơ sở hạ tầng của mình.
+
+Trong bài viết này, chúng ta sẽ khám phá một số giải pháp thay thế SaaS mã nguồn mở tốt nhất mà bạn có thể tự lưu trữ bằng Docker. Mỗi công cụ đi kèm với mô tả ngắn gọn, tóm tắt chức năng, trường hợp sử dụng, kho lưu trữ GitHub và các lệnh Docker để bắt đầu.
+
+---
+
+### 1. **Webstudio**
+
+- **Danh mục**: Trình xây dựng Trang web  
+- **Thay thế cho**: Webflow, Wix  
+- **Mô tả**: Webstudio là một trình xây dựng trang web mã nguồn mở cho phép người dùng tạo các trang web hiện đại, đáp ứng mà không cần viết mã. Đây là một giải pháp thay thế tuyệt vời cho các công cụ độc quyền như Webflow hoặc Wix.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/webstudio.png)
+- **Tính năng**:  
+  - Giao diện kéo và thả  
+  - Thiết kế đáp ứng  
+  - Thành phần có thể tùy chỉnh  
+  - Triển khai tự lưu trữ hoặc đám mây  
+- **Liên kết GitHub**: [Webstudio trên GitHub](https://github.com/webstudio-is/webstudio) (⭐ 2.5k)  
+- **Trang chủ**: [Webstudio](https://webstudio.is)  
+
+---
+
+### 2. **Pocketbase**
+
+- **Danh mục**: Backend/Cơ sở dữ liệu  
+- **Thay thế cho**: Firebase, Supabase  
+- **Mô tả**: Pocketbase là một giải pháp backend mã nguồn mở, nhẹ cung cấp cơ sở dữ liệu thời gian thực, xác thực và lưu trữ tệp. Đây là một giải pháp thay thế tuyệt vời cho Firebase hoặc Supabase dành cho các nhà phát triển muốn kiểm soát nhiều hơn đối với cơ sở hạ tầng backend của họ.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/pocketbase.png)
+- **Tính năng**:  
+  - Cơ sở dữ liệu thời gian thực  
+  - Xác thực tích hợp  
+  - Lưu trữ tệp  
+  - Dễ dàng thiết lập và tự lưu trữ  
+- **Liên kết GitHub**: [Pocketbase trên GitHub](https://github.com/pocketbase/pocketbase) (⭐ 25k)  
+- **Trang chủ**: [Pocketbase](https://pocketbase.io)  
+
+---
+
+### 3. **Rowy**
+
+- **Danh mục**: Quản lý Cơ sở dữ liệu  
+- **Thay thế cho**: Airtable, Retool  
+- **Mô tả**: Rowy là một nền tảng mã nguồn mở biến Firebase hoặc Google Sheets của bạn thành một công cụ quản lý cơ sở dữ liệu mạnh mẽ. Đây là một giải pháp thay thế tuyệt vời cho Airtable hoặc Retool để quản lý và trực quan hóa dữ liệu.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/rowy.png)
+- **Tính năng**:  
+  - Giao diện giống bảng tính  
+  - Tích hợp với Firebase  
+  - Quy trình làm việc có thể tùy chỉnh  
+  - Cộng tác thời gian thực  
+- **Liên kết GitHub**: [Rowy trên GitHub](https://github.com/rowyio/rowy) (⭐ 4.2k)  
+- **Trang chủ**: [Rowy](https://www.rowy.io)  
+
+---
+
+### 4. **Notesnook**
+
+- **Danh mục**: Ứng dụng Ghi chú  
+- **Thay thế cho**: Evernote, Notion  
+- **Mô tả**: Notesnook là một ứng dụng ghi chú mã nguồn mở, tập trung vào quyền riêng tư giúp bạn tổ chức suy nghĩ một cách an toàn. Đây là một giải pháp thay thế tuyệt vời cho Evernote hoặc Notion dành cho người dùng ưu tiên quyền riêng tư dữ liệu.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/notesnook.webp)
+- **Tính năng**:  
+  - Mã hóa đầu cuối  
+  - Đồng bộ đa nền tảng  
+  - Chỉnh sửa văn bản phong phú  
+  - Gắn thẻ và tổ chức  
+- **Liên kết GitHub**: [Notesnook trên GitHub](https://github.com/streetwriters/notesnook) (⭐ 3.8k)  
+- **Trang chủ**: [Notesnook](https://notesnook.com)  
+
+---
+
+### 5. **Outline**
+
+- **Danh mục**: Quản lý Kiến thức  
+- **Thay thế cho**: Confluence, Notion  
+- **Mô tả**: Outline là một công cụ kiến thức nền tảng và wiki mã nguồn mở được thiết kế cho các nhóm cộng tác và ghi lại công việc của họ. Đây là một giải pháp thay thế tuyệt vời cho Confluence hoặc Notion để tạo và chia sẻ kiến thức.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/outlines.png)
+- **Tính năng**:  
+  - Hỗ trợ Markdown  
+  - Cộng tác nhóm  
+  - Lịch sử phiên bản  
+  - Triển khai tự lưu trữ hoặc đám mây  
+- **Liên kết GitHub**: [Outline trên GitHub](https://github.com/outline/outline) (⭐ 21k)  
+- **Trang chủ**: [Outline](https://www.getoutline.com)  
+
+---
+
+### 6. **Sonic**
+
+- **Danh mục**: Công cụ Tìm kiếm  
+- **Thay thế cho**: Algolia, Elasticsearch  
+- **Mô tả**: Sonic là một công cụ tìm kiếm mã nguồn mở, nhẹ cung cấp khả năng tìm kiếm toàn văn nhanh chóng và hiệu quả. Đây là một giải pháp thay thế tuyệt vời cho Algolia hoặc Elasticsearch dành cho các nhà phát triển cần một giải pháp tìm kiếm đơn giản, hiệu suất cao.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/sonic.jpeg)
+- **Tính năng**:  
+  - Tìm kiếm toàn văn nhanh  
+  - Sử dụng tài nguyên thấp  
+  - Tích hợp dễ dàng  
+  - Lập chỉ mục thời gian thực  
+- **Liên kết GitHub**: [Sonic trên GitHub](https://github.com/valeriansaliou/sonic) (⭐ 19k)  
+- **Trang chủ**: [Sonic](https://crates.io/crates/sonic-server)  
+
+---
+
+### 7. **Kuma (Uptime Kuma)**
+
+- **Danh mục**: Giám sát  
+- **Thay thế cho**: UptimeRobot, Pingdom  
+- **Mô tả**: Kuma, còn được gọi là Uptime Kuma, là một công cụ giám sát mã nguồn mở giúp bạn theo dõi thời gian hoạt động và hiệu suất của các trang web và dịch vụ. Đây là một giải pháp thay thế tuyệt vời cho UptimeRobot hoặc Pingdom dành cho những ai muốn một giải pháp tự lưu trữ.  
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/kuma.jpg)
+- **Tính năng**:  
+  - Giám sát thời gian hoạt động thời gian thực  
+  - Cảnh báo có thể tùy chỉnh  
+  - Bảng điều khiển đẹp mắt  
+  - Tự lưu trữ và nhẹ  
+- **Liên kết GitHub**: [Kuma trên GitHub](https://github.com/louislam/uptime-kuma) (⭐ 40k)  
+- **Trang chủ**: [Uptime Kuma](https://uptime.kuma.pet)  
+
+---
+
+### Tại Sao Chọn Giải Pháp Thay Thế Mã Nguồn Mở?
+
+Các công cụ mã nguồn mở mang lại một số lợi thế so với các đối thủ độc quyền:  
+
+- **Tiết kiệm Chi phí**: Hầu hết các công cụ mã nguồn mở đều miễn phí sử dụng, tiết kiệm phí đăng ký.  
+- **Tùy chỉnh**: Bạn có thể sửa đổi mã để phù hợp với nhu cầu cụ thể của mình.  
+- **Quyền riêng tư Dữ liệu**: Các giải pháp tự lưu trữ đảm bảo dữ liệu của bạn nằm trong tầm kiểm soát của bạn.  
+- **Hỗ trợ Cộng đồng**: Các dự án mã nguồn mở thường có cộng đồng tích cực đóng góp vào sự phát triển và cung cấp hỗ trợ.  
+
+---
+
+### Kết Luận
+
+Hệ sinh thái mã nguồn mở đang phát triển mạnh mẽ và có rất nhiều giải pháp thay thế chất lượng cao cho các công cụ SaaS phổ biến. Dù bạn là nhà phát triển, chủ doanh nghiệp hay người dùng cá nhân, các giải pháp mã nguồn mở này có thể giúp bạn đạt được mục tiêu mà không tốn kém hoặc ảnh hưởng đến quyền riêng tư.  
+
+Từ trình xây dựng trang web như **Webstudio** đến công cụ giám sát như **Kuma**, các lựa chọn rất đa dạng và linh hoạt. Vậy tại sao không thử các giải pháp thay thế mã nguồn mở này? Bạn có thể tìm thấy công cụ yêu thích mới của mình!  

--- a/src/content/posts/open-source-crm-Bottelet-DaybydayCRM-vi.md
+++ b/src/content/posts/open-source-crm-Bottelet-DaybydayCRM-vi.md
@@ -1,0 +1,99 @@
+---
+lang: vi
+title: "DaybydayCRM: Một CRM Mã Nguồn Mở Mạnh Mẽ Cho Quản Lý Quy Trình Làm Việc Hàng Ngày"
+description: "Khám phá DaybydayCRM, một công cụ quản lý quan hệ khách hàng mã nguồn mở được thiết kế để hợp lý hóa quy trình làm việc hàng ngày và cải thiện năng suất."
+published: 2025-08-18
+tags: ['open-source', 'self-host', 'crm', 'php', 'laravel', 'docker']
+category: Self-hosted
+author: minhpt
+---
+
+# Bottelet/DaybydayCRM - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub  
+- **URL:** [https://github.com/Bottelet/DaybydayCRM](https://github.com/Bottelet/DaybydayCRM)  
+- **Sao:** 2283  
+
+## 2. Mô Tả Dự Án  
+**DaybydayCRM** là một hệ thống Quản lý Quan hệ Khách hàng (CRM) mã nguồn mở được thiết kế để giúp các doanh nghiệp và cá nhân theo dõi quy trình làm việc hàng ngày của họ một cách hiệu quả. Được xây dựng với PHP và Laravel, CRM này cung cấp giao diện sạch sẽ, thân thiện với người dùng để quản lý liên hệ, tác vụ, cuộc hẹn và dự án. Không giống như các CRM doanh nghiệp cồng kềnh, DaybydayCRM tập trung vào sự đơn giản trong khi vẫn cung cấp các tính năng thiết yếu cho các nhóm nhỏ và vừa.  
+
+## 3. Phần Mềm Này Thay Thế Những Gì?  
+DaybydayCRM phục vụ như một giải pháp thay thế miễn phí và mã nguồn mở cho các giải pháp CRM thương mại như:  
+- **Salesforce** (cho các nhóm nhỏ cần chức năng CRM cơ bản)  
+- **HubSpot CRM** (cho những người thích tự lưu trữ)  
+- **Zoho CRM** (cho người dùng tìm kiếm giải pháp thay thế nhẹ)  
+
+## 4. Chức Năng Chính  
+Các tính năng chính của DaybydayCRM bao gồm:  
+- **Quản lý Liên hệ & Khách hàng tiềm năng** – Lưu trữ và tổ chức thông tin khách hàng hiệu quả.  
+- **Theo dõi Tác vụ & Cuộc hẹn** – Lên lịch và quản lý các hoạt động hàng ngày.  
+- **Quản lý Dự án** – Giao tác vụ, theo dõi tiến độ và cộng tác với các thành viên trong nhóm.  
+- **Báo cáo & Phân tích** – Tạo thông tin chi tiết về hiệu quả quy trình làm việc.  
+- **Hỗ trợ Nhiều Người dùng** – Kiểm soát truy cập dựa trên vai trò cho các nhóm.  
+- **API & Tích hợp** – Mở rộng chức năng với các công cụ bên thứ ba.  
+
+## 5. Ưu và Nhược Điểm  
+
+### **Ưu điểm:**  
+✔ **Mã nguồn Mở & Miễn phí** – Không có chi phí cấp phép.  
+✔ **Có thể Tự lưu trữ** – Toàn quyền kiểm soát dữ liệu và quyền riêng tư.  
+✔ **Nhẹ & Nhanh** – Được xây dựng với Laravel cho hiệu suất.  
+✔ **Giao diện Hiện đại** – Bảng điều khiển sạch sẽ và trực quan.  
+
+### **Nhược điểm:**  
+❌ **Tính năng Nâng cao Hạn chế** – Không lý tưởng cho doanh nghiệp lớn.  
+❌ **Yêu cầu Thiết lập Kỹ thuật** – Tự lưu trữ có thể cần kiến thức máy chủ.  
+❌ **Cộng đồng Nhỏ hơn** – Ít plugin/tiện ích mở rộng hơn so với CRM thương mại.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)  
+
+### **Yêu cầu:**  
+- **Máy chủ Linux (Ubuntu 20.04/22.04 được khuyến nghị)**  
+- **Docker & Docker Compose** (để triển khai container hóa)  
+- **Git** (để clone kho lưu trữ)  
+
+### **Cài đặt Từng bước:**  
+
+#### **1. Cài đặt Docker & Docker Compose**  
+```bash
+sudo apt update && sudo apt install -y docker.io docker-compose
+sudo systemctl enable --now docker
+```
+
+#### **2. Clone Kho Lưu trữ**  
+```bash
+git clone https://github.com/Bottelet/DaybydayCRM.git
+cd DaybydayCRM
+```
+
+#### **3. Cấu hình Biến Môi trường**  
+Sao chép tệp `.env.example` và sửa đổi nó:  
+```bash
+cp .env.example .env
+nano .env  # Cập nhật cơ sở dữ liệu, URL ứng dụng và cài đặt mail
+```
+
+#### **4. Khởi động Ứng dụng với Docker**  
+```bash
+docker-compose up -d
+```
+
+#### **5. Chạy Di chuyển Cơ sở dữ liệu & Dữ liệu Mẫu**  
+```bash
+docker-compose exec app php artisan migrate --seed
+```
+
+#### **6. Truy cập CRM**  
+Mở trình duyệt và điều hướng đến:  
+```
+http://dia-chi-may-chu-cua-ban:8000
+```
+
+#### **7. (Tùy chọn) Thiết lập Reverse Proxy Nginx**  
+Để sử dụng trong sản xuất, cấu hình Nginx hoặc Apache để phục vụ DaybydayCRM một cách an toàn với HTTPS.  
+
+### **Kết Luận**  
+DaybydayCRM là một lựa chọn tuyệt vời cho các nhóm tìm kiếm giải pháp CRM mã nguồn mở, tự lưu trữ. Mặc dù có thể thiếu một số tính năng cấp doanh nghiệp, sự đơn giản và các tùy chọn tùy chỉnh làm cho nó trở thành ứng cử viên mạnh mẽ cho các doanh nghiệp nhỏ và freelancer.  
+
+Để biết thêm chi tiết, hãy truy cập [kho lưu trữ GitHub chính thức](https://github.com/Bottelet/DaybydayCRM).  
+```

--- a/src/content/posts/open-source-crm-Dolibarr-dolibarr-vi.md
+++ b/src/content/posts/open-source-crm-Dolibarr-dolibarr-vi.md
@@ -1,0 +1,142 @@
+---
+lang: vi
+title: "Dolibarr ERP CRM – Giải Pháp Quản Lý Kinh Doanh Mã Nguồn Mở Toàn Diện"
+description: "Khám phá Dolibarr, hệ thống ERP và CRM mã nguồn mở dành cho doanh nghiệp ở mọi quy mô. Tìm hiểu các tính năng, ưu & nhược điểm và cách tự lưu trữ."
+published: 2025-08-13
+tags: ['open-source', 'self-host', 'erp', 'crm', 'php', 'business-management']
+category: Self-hosted
+author: minhpt
+---
+
+# Dolibarr/dolibarr - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub  
+- **URL:** [https://github.com/Dolibarr/dolibarr](https://github.com/Dolibarr/dolibarr)  
+- **Sao:** 5951 (tính đến tháng 8/2025)  
+
+## 2. Mô Tả Dự Án  
+**Dolibarr ERP CRM** là một ứng dụng web mã nguồn mở hiện đại được thiết kế để giúp các doanh nghiệp, freelancer và tổ chức quản lý hoạt động của họ một cách hiệu quả. Được viết bằng PHP, nó tích hợp các chức năng **Hoạch định Nguồn lực Doanh nghiệp (ERP)** và **Quản lý Quan hệ Khách hàng (CRM)** vào một nền tảng duy nhất.  
+
+Các khía cạnh chính bao gồm:  
+✔ **Thiết kế mô-đun** – Chỉ cài đặt các tính năng bạn cần.  
+✔ **Tự lưu trữ** – Toàn quyền kiểm soát dữ liệu của bạn.  
+✔ **Hỗ trợ nhiều người dùng & nhiều công ty** – Lý tưởng cho các doanh nghiệp đang phát triển.  
+
+## 3. Phần Mềm Này Thay Thế Những Gì?  
+Dolibarr phục vụ như một giải pháp thay thế miễn phí, mã nguồn mở cho các giải pháp thương mại như:  
+- **SAP Business One** (ERP)  
+- **Salesforce CRM** (CRM)  
+- **Odoo** (ERP/CRM)  
+- **Microsoft Dynamics 365**  
+
+Đối với doanh nghiệp nhỏ, nó có thể thay thế các công cụ độc lập như **QuickBooks (kế toán)**, **Zoho CRM** hoặc **HubSpot**.
+
+## 4. Chức Năng Chính  
+Cấu trúc mô-đun của Dolibarr cho phép doanh nghiệp chỉ bật các tính năng họ cần:  
+
+### **Tính năng ERP**  
+- **Hóa đơn & Thanh toán** – Tạo báo giá, hóa đơn và theo dõi thanh toán.  
+- **Quản lý Hàng tồn kho & Kho** – Quản lý sản phẩm, nhà kho và đơn hàng.  
+- **Kế toán** – Kế toán kép với xuất sang phần mềm kế toán.  
+- **Quản lý Nhân sự & Dự án** – Theo dõi nhân viên, bảng chấm công và dự án.  
+
+### **Tính năng CRM**  
+- **Quản lý Liên hệ & Khách hàng tiềm năng** – Lưu trữ thông tin khách hàng và theo dõi tương tác.  
+- **Chiến dịch Email** – Gửi email hàng loạt và bản tin.  
+- **Lên lịch Sự kiện** – Quản lý cuộc họp và tác vụ qua lịch tích hợp.  
+
+### **Mô-đun Bổ sung**  
+- **Điểm Bán hàng (POS)** – Cho doanh nghiệp bán lẻ.  
+- **Quyên góp & Thành viên** – Lý tưởng cho tổ chức phi lợi nhuận.  
+- **Tích hợp Thương mại điện tử** – Kết nối với các nền tảng như WooCommerce.  
+
+## 5. Ưu và Nhược Điểm  
+
+### **Ưu điểm ✅**  
+✔ **Mã nguồn Mở & Miễn phí** – Không có chi phí cấp phép.  
+✔ **Có thể Tùy chỉnh Cao** – Thêm hoặc xóa mô-đun khi cần.  
+✔ **Tự lưu trữ** – Đảm bảo quyền riêng tư và bảo mật dữ liệu.  
+✔ **Đa ngôn ngữ & Đa tiền tệ** – Hỗ trợ doanh nghiệp toàn cầu.  
+
+### **Nhược điểm ❌**  
+❌ **Đường cong Học tập Dốc** – Cần thời gian để làm chủ tất cả các tính năng.  
+❌ **Ứng dụng Di động Hạn chế** – Giao diện dựa trên web có thể không thân thiện với di động.  
+❌ **Chỉ Hỗ trợ Cộng đồng** – Không có hỗ trợ doanh nghiệp chuyên dụng (có gói trả phí để được hỗ trợ).  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ trên Ubuntu)  
+
+### **Yêu cầu**  
+- **Ubuntu 22.04 LTS** (hoặc mới hơn)  
+- **LAMP Stack** (Linux, Apache, MySQL, PHP)  
+- **Composer** (Trình quản lý phụ thuộc PHP)  
+
+### **Thiết lập Từng bước**  
+
+#### **1. Cài đặt LAMP Stack**  
+```bash
+sudo apt update && sudo apt upgrade -y  
+sudo apt install apache2 mysql-server php libapache2-mod-php php-mysql php-curl php-gd php-zip php-xml -y  
+```
+
+#### **2. Cấu hình MySQL**  
+Bảo mật MySQL và tạo cơ sở dữ liệu:  
+```bash
+sudo mysql_secure_installation  
+sudo mysql -u root -p  
+CREATE DATABASE dolibarr_db;  
+CREATE USER 'doliuser'@'localhost' IDENTIFIED BY 'YourSecurePassword';  
+GRANT ALL PRIVILEGES ON dolibarr_db.* TO 'doliuser'@'localhost';  
+FLUSH PRIVILEGES;  
+EXIT;  
+```
+
+#### **3. Cài đặt Dolibarr**  
+```bash
+cd /var/www/html  
+sudo git clone https://github.com/Dolibarr/dolibarr.git  
+cd dolibarr  
+sudo chown -R www-data:www-data /var/www/html/dolibarr  
+```
+
+#### **4. Cấu hình Apache**  
+Tạo một virtual host:  
+```bash
+sudo nano /etc/apache2/sites-available/dolibarr.conf  
+```
+Dán:  
+```apache
+<VirtualHost *:80>
+    ServerAdmin admin@yourdomain.com  
+    DocumentRoot /var/www/html/dolibarr/htdocs  
+    ServerName yourdomain.com  
+    <Directory /var/www/html/dolibarr/htdocs>  
+        Options FollowSymLinks  
+        AllowOverride All  
+        Require all granted  
+    </Directory>  
+</VirtualHost>  
+```
+Kích hoạt site:  
+```bash
+sudo a2ensite dolibarr.conf  
+sudo a2enmod rewrite  
+sudo systemctl restart apache2  
+```
+
+#### **5. Hoàn tất Thiết lập qua Web Installer**  
+- Truy cập `http://yourdomain.com/install` trong trình duyệt.  
+- Làm theo hướng dẫn trên màn hình để cấu hình Dolibarr.  
+- Nhập thông tin đăng nhập MySQL khi được yêu cầu.  
+
+### **Cài đặt Tùy chọn: Docker**  
+Đối với người dùng Docker:  
+```bash
+docker run -d --name dolibarr -p 80:80 -v dolibarr_data:/var/www/html/dolibarr -e PHP_TIMEZONE="UTC" dolibarr/dolibarr:latest  
+```
+
+### **Lưu ý Cuối cùng**  
+✔ Bảo mật cài đặt của bạn với **HTTPS** (sử dụng Let's Encrypt).  
+✔ Thường xuyên sao lưu thư mục `/var/www/html/dolibarr` và cơ sở dữ liệu.  
+
+Dolibarr là một giải pháp mạnh mẽ, tiết kiệm chi phí cho các doanh nghiệp muốn hợp lý hóa hoạt động mà không bị khóa nhà cung cấp. Hãy dùng thử ngay hôm nay!  
+```

--- a/src/content/posts/open-source-crm-InvoicePlane-InvoicePlane-vi.md
+++ b/src/content/posts/open-source-crm-InvoicePlane-InvoicePlane-vi.md
@@ -1,0 +1,120 @@
+---
+lang: vi
+title: "InvoicePlane: Giải Pháp Lập Hóa Đơn Mã Nguồn Mở Mạnh Mẽ Cho Tự Lưu Trữ"
+description: "Khám phá InvoicePlane, hệ thống quản lý hóa đơn và thanh toán mã nguồn mở, tự lưu trữ thay thế các giải pháp thương mại."
+published: 2025-08-16
+tags: ['open-source', 'self-host', 'invoicing', 'php', 'billing']
+category: Self-hosted
+author: minhpt
+---
+
+# InvoicePlane/InvoicePlane - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/InvoicePlane/InvoicePlane](https://github.com/InvoicePlane/InvoicePlane)
+- **Sao:** 2701 (tính đến tháng 8/2025)
+
+## 2. Mô Tả Dự Án
+**InvoicePlane** là một ứng dụng lập hóa đơn mã nguồn mở, tự lưu trữ được thiết kế để giúp các freelancer, doanh nghiệp nhỏ và tổ chức quản lý khách hàng, hóa đơn và thanh toán một cách hiệu quả. Được xây dựng với PHP và MySQL, nó cung cấp giao diện sạch sẽ, thân thiện để tạo hóa đơn chuyên nghiệp, theo dõi thanh toán và quản lý dữ liệu khách hàng—tất cả mà không phụ thuộc vào dịch vụ bên thứ ba.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+InvoicePlane phục vụ như một giải pháp thay thế miễn phí và mã nguồn mở cho các giải pháp lập hóa đơn thương mại như:
+- **QuickBooks Online**
+- **FreshBooks**
+- **Zoho Invoice**
+- **Wave Apps**
+- **Xero**
+
+## 4. Chức Năng Chính
+Các tính năng chính của InvoicePlane bao gồm:
+- **Quản lý Hóa đơn:** Tạo, gửi và theo dõi hóa đơn với các mẫu có thể tùy chỉnh.
+- **Quản lý Khách hàng:** Lưu trữ thông tin khách hàng, điều khoản thanh toán và lịch sử giao dịch.
+- **Theo dõi Thanh toán:** Ghi lại và đối chiếu thanh toán với hỗ trợ nhiều phương thức thanh toán.
+- **Hóa đơn Định kỳ:** Tự động hóa chu kỳ thanh toán cho đăng ký hoặc khách hàng thường xuyên.
+- **Thuế & Báo cáo:** Tính thuế và tạo báo cáo tài chính.
+- **Hỗ trợ Đa ngôn ngữ:** Có sẵn bằng nhiều ngôn ngữ để sử dụng toàn cầu.
+- **Xuất PDF:** Tải xuống hóa đơn dưới dạng PDF để sử dụng ngoại tuyến.
+
+## 5. Ưu và Nhược Điểm
+### **Ưu điểm:**
+✔ **Tự lưu trữ & Riêng tư:** Toàn quyền kiểm soát dữ liệu hóa đơn của bạn.  
+✔ **Không có Phí Đăng ký:** Không giống như các lựa chọn thay thế SaaS, InvoicePlane miễn phí sử dụng.  
+✔ **Có thể Tùy chỉnh:** Sửa đổi mẫu và quy trình làm việc để phù hợp với nhu cầu kinh doanh của bạn.  
+✔ **Truy cập Ngoại tuyến:** Hoạt động mà không cần kết nối internet sau khi cài đặt.  
+
+### **Nhược điểm:**
+✖ **Yêu cầu Thiết lập Kỹ thuật:** Cần máy chủ web (Apache/Nginx), PHP và MySQL.  
+✖ **Hỗ trợ Di động Hạn chế:** Không có ứng dụng di động chuyên dụng (chỉ giao diện web).  
+✖ **Không có Xử lý Thanh toán Tích hợp:** Yêu cầu tích hợp thủ công với các cổng như PayPal hoặc Stripe.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ trên Ubuntu)
+### **Yêu cầu:**
+- **Ubuntu 22.04 LTS** (hoặc mới hơn)  
+- **LAMP Stack** (Apache, MySQL, PHP)  
+- **Composer** (Trình quản lý phụ thuộc PHP)  
+
+### **Thiết lập Từng bước:**
+1. **Cài đặt LAMP Stack**  
+   ```bash
+   sudo apt update && sudo apt install apache2 mysql-server php libapache2-mod-php php-mysql php-curl php-gd php-mbstring php-xml php-zip
+   ```
+
+2. **Cấu hình MySQL**  
+   ```bash
+   sudo mysql_secure_installation
+   sudo mysql -u root -p
+   ```
+   Trong MySQL, tạo cơ sở dữ liệu và người dùng cho InvoicePlane:
+   ```sql
+   CREATE DATABASE invoiceplane;
+   CREATE USER 'ip_user'@'localhost' IDENTIFIED BY 'your_password';
+   GRANT ALL PRIVILEGES ON invoiceplane.* TO 'ip_user'@'localhost';
+   FLUSH PRIVILEGES;
+   ```
+
+3. **Cài đặt InvoicePlane**  
+   ```bash
+   cd /var/www/html
+   sudo git clone https://github.com/InvoicePlane/InvoicePlane.git
+   cd InvoicePlane
+   sudo composer install --no-dev
+   ```
+
+4. **Đặt Quyền**  
+   ```bash
+   sudo chown -R www-data:www-data /var/www/html/InvoicePlane
+   sudo chmod -R 755 /var/www/html/InvoicePlane
+   ```
+
+5. **Cấu hình Apache**  
+   Tạo virtual host:
+   ```bash
+   sudo nano /etc/apache2/sites-available/invoiceplane.conf
+   ```
+   Dán nội dung sau (điều chỉnh `ServerName` khi cần):
+   ```apache
+   <VirtualHost *:80>
+       ServerName invoicing.yourdomain.com
+       DocumentRoot /var/www/html/InvoicePlane
+       <Directory /var/www/html/InvoicePlane>
+           Options Indexes FollowSymLinks
+           AllowOverride All
+           Require all granted
+       </Directory>
+   </VirtualHost>
+   ```
+   Kích hoạt site và khởi động lại Apache:
+   ```bash
+   sudo a2ensite invoiceplane.conf
+   sudo systemctl restart apache2
+   ```
+
+6. **Chạy Trình Cài đặt**  
+   Truy cập `http://your-server-ip` trong trình duyệt và làm theo trình hướng dẫn thiết lập để cấu hình InvoicePlane.
+
+### **Sau khi Cài đặt:**
+- Bảo mật cài đặt của bạn với HTTPS (sử dụng Let's Encrypt).  
+- Thiết lập sao lưu tự động cho cơ sở dữ liệu MySQL.  
+
+**Tận hưởng hệ thống lập hóa đơn tự lưu trữ của bạn!** 🚀
+```

--- a/src/content/posts/open-source-crm-MicroPyramid-Django-CRM-vi.md
+++ b/src/content/posts/open-source-crm-MicroPyramid-Django-CRM-vi.md
@@ -1,0 +1,171 @@
+---
+lang: vi
+title: "MicroPyramid/Django-CRM: Giải Pháp CRM Mã Nguồn Mở Tối Ưu Cho Nhà Phát Triển Django"
+description: "Đánh giá toàn diện về MicroPyramid/Django-CRM - một CRM mã nguồn mở được xây dựng trên Django. Tính năng, hướng dẫn cài đặt, ưu và nhược điểm cho tự lưu trữ."
+published: 2025-08-20
+tags: ['open-source', 'self-host', 'django', 'python', 'crm', 'business-automation']
+category: Self-hosted
+author: minhpt
+---
+
+# MicroPyramid/Django-CRM - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/MicroPyramid/Django-CRM](https://github.com/MicroPyramid/Django-CRM)
+- **Sao:** 2042
+- **Giấy phép:** MIT License
+- **Cập nhật Lần cuối:** Tháng 8/2024
+
+## 2. Mô Tả Dự Án
+
+MicroPyramid/Django-CRM là một hệ thống Quản lý Quan hệ Khách hàng toàn diện, mã nguồn mở được xây dựng trên framework web Django. Giải pháp mạnh mẽ này cung cấp cho doanh nghiệp một bộ công cụ hoàn chỉnh để quản lý tương tác khách hàng, kênh bán hàng, chiến dịch tiếp thị và hỗ trợ khách hàng. Được thiết kế với tính linh hoạt, nó cung cấp một giải pháp thay thế hiện đại cho các nền tảng CRM thương mại đắt tiền trong khi vẫn duy trì chức năng cấp doanh nghiệp.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Dự án này phục vụ như một giải pháp thay thế khả thi cho một số giải pháp CRM phổ biến:
+
+- **Nền tảng Thương mại:** Salesforce, HubSpot CRM, Zoho CRM
+- **Lựa chọn Thay thế Mã nguồn Mở:** SuiteCRM, Odoo CRM, EspoCRM
+- **Giải pháp SaaS:** Pipedrive, Freshsales, Insightly
+
+## 4. Chức Năng Chính
+
+Django-CRM cung cấp một bộ tính năng mở rộng bao gồm:
+
+- **Quản lý Liên hệ:** Cơ sở dữ liệu khách hàng hoàn chỉnh với hồ sơ chi tiết
+- **Theo dõi Khách hàng tiềm năng:** Kênh bán hàng trực quan với các giai đoạn có thể tùy chỉnh
+- **Quản lý Tác vụ:** Giao và theo dõi các hoạt động và lời nhắc của nhóm
+- **Tích hợp Email:** Gửi và nhận email trực tiếp trong nền tảng
+- **Quản lý Tài liệu:** Lưu trữ và tổ chức các tệp liên quan đến khách hàng
+- **Báo cáo & Phân tích:** Tạo thông tin chi tiết với bảng điều khiển có thể tùy chỉnh
+- **Cộng tác Nhóm:** Kiểm soát truy cập dựa trên vai trò và quản lý nhóm
+- **Đáp ứng Di động:** Hoạt động đầy đủ trên máy tính để bàn và thiết bị di động
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- ✅ Hoàn toàn miễn phí và mã nguồn mở
+- ✅ Được xây dựng trên Django (framework ổn định và có tài liệu tốt)
+- ✅ Giải pháp tự lưu trữ với toàn quyền kiểm soát dữ liệu
+- ✅ Có thể tùy chỉnh và mở rộng cao
+- ✅ Cộng đồng tích cực và cập nhật thường xuyên
+- ✅ Giấy phép MIT cho phép sử dụng thương mại
+
+**Nhược điểm:**
+- ❌ Yêu cầu kiến thức kỹ thuật để thiết lập và bảo trì
+- ❌ Không có tùy chọn lưu trữ SaaS chính thức
+- ❌ Tích hợp dựng sẵn hạn chế so với các lựa chọn thay thế thương mại
+- ❌ Đường cong học tập dốc hơn cho người dùng phi kỹ thuật
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Máy chủ Ubuntu 20.04/22.04 LTS
+- Python 3.8+
+- PostgreSQL 12+
+- Redis server
+- Nginx web server
+
+### Cài đặt Từng bước
+
+**1. Cập nhật Hệ thống và Cài đặt Phụ thuộc**
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install python3-pip python3-dev libpq-dev postgresql postgresql-contrib nginx redis-server -y
+```
+
+**2. Tạo Cơ sở dữ liệu và Người dùng**
+```bash
+sudo -u postgres psql
+CREATE DATABASE djangocrm;
+CREATE USER djangouser WITH PASSWORD 'your_secure_password';
+ALTER ROLE djangouser SET client_encoding TO 'utf8';
+ALTER ROLE djangouser SET default_transaction_isolation TO 'read committed';
+ALTER ROLE djangouser SET timezone TO 'UTC';
+GRANT ALL PRIVILEGES ON DATABASE djangocrm TO djangouser;
+\q
+```
+
+**3. Clone và Thiết lập Dự án**
+```bash
+git clone https://github.com/MicroPyramid/Django-CRM.git
+cd Django-CRM
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+**4. Cấu hình Biến Môi trường**
+```bash
+cp .env.example .env
+nano .env
+```
+Cập nhật các biến sau:
+```
+DATABASE_URL=postgres://djangouser:your_secure_password@localhost:5432/djangocrm
+SECRET_KEY=your_very_secure_secret_key_here
+DEBUG=False
+```
+
+**5. Chạy Migrations và Tạo Superuser**
+```bash
+python manage.py migrate
+python manage.py createsuperuser
+```
+
+**6. Cấu hình Gunicorn**
+```bash
+sudo nano /etc/systemd/system/gunicorn.service
+```
+Thêm cấu hình:
+```ini
+[Unit]
+Description=gunicorn daemon
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/path/to/Django-CRM
+ExecStart=/path/to/Django-CRM/venv/bin/gunicorn --access-logfile - --workers 3 --bind unix:/path/to/Django-CRM/djangocrm.sock djangocrm.wsgi:application
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**7. Cấu hình Nginx**
+```bash
+sudo nano /etc/nginx/sites-available/djangocrm
+```
+Thêm cấu hình máy chủ:
+```nginx
+server {
+    listen 80;
+    server_name your_domain.com;
+
+    location / {
+        include proxy_params;
+        proxy_pass http://unix:/path/to/Django-CRM/djangocrm.sock;
+    }
+    
+    location /static/ {
+        alias /path/to/Django-CRM/static/;
+    }
+    
+    location /media/ {
+        alias /path/to/Django-CRM/media/;
+    }
+}
+```
+
+**8. Các Bước Cuối cùng**
+```bash
+sudo ln -s /etc/nginx/sites-available/djangocrm /etc/nginx/sites-enabled
+sudo systemctl daemon-reload
+sudo systemctl start gunicorn
+sudo systemctl enable gunicorn
+sudo systemctl restart nginx
+```
+
+Phiên bản Django-CRM của bạn hiện đang chạy và có thể truy cập tại địa chỉ IP hoặc tên miền của máy chủ! Đừng quên thiết lập chứng chỉ SSL với Certbot để sử dụng trong sản xuất.

--- a/src/content/posts/open-source-crm-ONLYOFFICE-CommunityServer-vi.md
+++ b/src/content/posts/open-source-crm-ONLYOFFICE-CommunityServer-vi.md
@@ -1,0 +1,99 @@
+---
+lang: vi
+title: "ONLYOFFICE CommunityServer: Giải Pháp Thay Thế Bộ Văn Phòng Mã Nguồn Mở Miễn Phí"
+description: "Khám phá ONLYOFFICE CommunityServer, một bộ văn phòng mã nguồn mở mạnh mẽ với quản lý tài liệu, CRM và tổng hợp thư."
+published: 2025-08-15
+tags: ['open-source', 'self-host', 'office-suite', 'document-management', 'crm', 'docker']
+category: Self-hosted
+author: minhpt
+---
+
+# ONLYOFFICE/CommunityServer - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+- **URL:** [https://github.com/ONLYOFFICE/CommunityServer](https://github.com/ONLYOFFICE/CommunityServer)  
+- **Sao:** 2863  
+
+ONLYOFFICE CommunityServer là một dự án mã nguồn mở phổ biến cung cấp bộ văn phòng toàn diện với các công cụ năng suất kinh doanh. Với hơn 2.800 sao trên GitHub, đây là một giải pháp thay thế được bảo trì tốt cho các bộ văn phòng thương mại.
+
+## 2. Mô Tả Dự Án
+ONLYOFFICE CommunityServer là một bộ văn phòng mã nguồn mở, miễn phí bao gồm:
+- **Chỉnh sửa tài liệu** (Word, Excel, PowerPoint và hơn thế nữa)
+- **Quản lý dự án** (tác vụ, biểu đồ Gantt, cột mốc)
+- **CRM** (quản lý quan hệ khách hàng)
+- **Trình tổng hợp thư** (hộp thư đến thống nhất cho nhiều tài khoản email)
+
+Được xây dựng cho doanh nghiệp và cá nhân cần một giải pháp văn phòng tự lưu trữ, tập trung vào quyền riêng tư, nó hỗ trợ cộng tác thời gian thực và tích hợp với các nền tảng phổ biến như Nextcloud, Seafile và ownCloud.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+ONLYOFFICE CommunityServer là một giải pháp thay thế mạnh mẽ cho:
+- **Microsoft 365 (Office 365)** – Cho chỉnh sửa và cộng tác tài liệu.
+- **Google Workspace** – Cho các công cụ văn phòng dựa trên đám mây.
+- **Zoho Workplace** – Cho bộ năng suất kinh doanh.
+- **Bitrix24** – Cho CRM và quản lý dự án.
+
+## 4. Chức Năng Chính
+Các tính năng chính bao gồm:
+- **Trình chỉnh sửa tài liệu trực tuyến** (hỗ trợ DOCX, XLSX, PPTX, ODT)
+- **Cộng tác thời gian thực** (chỉnh sửa nhiều người dùng với bình luận)
+- **Khả năng tự lưu trữ** (toàn quyền kiểm soát dữ liệu)
+- **CRM & quản lý dự án** (khách hàng tiềm năng, liên hệ, tác vụ, Kanban)
+- **Ứng dụng thư** (hộp thư đến thống nhất cho Gmail, Outlook, v.v.)
+- **API tích hợp** (hoạt động với Nextcloud, WordPress và hơn thế nữa)
+
+## 5. Ưu và Nhược Điểm
+### **Ưu điểm:**
+✔ **Mã nguồn mở & miễn phí** – Không có chi phí cấp phép.  
+✔ **Tự lưu trữ** – Toàn quyền sở hữu dữ liệu.  
+✔ **Giàu tính năng** – Không chỉ chỉnh sửa tài liệu.  
+✔ **Cộng tác thời gian thực** – Hoạt động như Google Docs.  
+✔ **Đa nền tảng** – Ứng dụng web, desktop và di động.  
+
+### **Nhược điểm:**
+❌ **Đường cong học tập dốc hơn** – Phức tạp hơn Google Docs.  
+❌ **Tốn tài nguyên** – Yêu cầu máy chủ khá tốt để tự lưu trữ.  
+❌ **Tích hợp bên thứ ba hạn chế** (so với Microsoft 365).  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+### **Yêu cầu:**
+- **Máy chủ Linux (Ubuntu 22.04 được khuyến nghị)**
+- **Docker & Docker Compose đã được cài đặt**
+- **Tối thiểu 4GB RAM (8GB được khuyến nghị cho sản xuất)**
+
+### **Thiết lập Từng bước:**
+1. **Cài đặt Docker & Docker Compose**
+   ```bash
+   sudo apt update && sudo apt install docker.io docker-compose
+   sudo systemctl enable --now docker
+   ```
+
+2. **Clone thiết lập Docker ONLYOFFICE**
+   ```bash
+   git clone https://github.com/ONLYOFFICE/Docker-CommunityServer.git
+   cd Docker-CommunityServer
+   ```
+
+3. **Chỉnh sửa tệp `.env`**
+   ```bash
+   nano .env
+   ```
+   - Đặt `ONLYOFFICE_HOST=ten-mien-cua-ban.com` (hoặc IP máy chủ nếu kiểm tra cục bộ).  
+   - Cấu hình thông tin đăng nhập cơ sở dữ liệu (PostgreSQL/MySQL).  
+
+4. **Khởi động ONLYOFFICE**
+   ```bash
+   sudo docker-compose up -d
+   ```
+
+5. **Truy cập Giao diện Web**
+   - Mở `http://dia-chi-may-chu-cua-ban` trong trình duyệt.  
+   - Hoàn tất thiết lập ban đầu (tài khoản quản trị, cấu hình cơ sở dữ liệu).  
+
+6. **(Tùy chọn) Bật HTTPS với Reverse Proxy Nginx**
+   ```bash
+   sudo apt install nginx certbot python3-certbot-nginx
+   sudo certbot --nginx -d ten-mien-cua-ban.com
+   ```
+
+Vậy là xong! ONLYOFFICE CommunityServer bây giờ sẽ chạy trên máy chủ của bạn. Để biết cấu hình nâng cao, hãy xem [tài liệu chính thức](https://helpcenter.onlyoffice.com/).
+```

--- a/src/content/posts/open-source-crm-Peppermint-Lab-peppermint-vi.md
+++ b/src/content/posts/open-source-crm-Peppermint-Lab-peppermint-vi.md
@@ -1,0 +1,106 @@
+---
+lang: vi
+title: "Peppermint: Giải Pháp Thay Thế Mã Nguồn Mở Cho Zendesk & Jira trong Quản Lý Vấn Đề"
+description: "Khám phá Peppermint, giải pháp quản lý vấn đề và help desk tự lưu trữ cạnh tranh với Zendesk và Jira. Tìm hiểu tính năng, ưu nhược điểm và cách triển khai."
+published: 2025-08-17
+tags: ['open-source', 'self-hosted', 'help-desk', 'issue-management', 'docker', 'javascript']
+category: 'Self-hosted'
+author: 'minhpt'
+---
+
+# Peppermint-Lab/peppermint - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub  
+- **URL:** [https://github.com/Peppermint-Lab/peppermint](https://github.com/Peppermint-Lab/peppermint)  
+- **Sao:** 2452  
+
+## 2. Mô Tả Dự Án  
+**Peppermint** là một giải pháp quản lý vấn đề và help desk mã nguồn mở, tự lưu trữ được thiết kế để thay thế cho các nền tảng thương mại như **Zendesk** và **Jira**. Được xây dựng với công nghệ web hiện đại, nó cung cấp quy trình làm việc hợp lý cho **ticket, hỗ trợ khách hàng và cộng tác nhóm**, lý tưởng cho các doanh nghiệp nhỏ, startup và doanh nghiệp đang tìm kiếm giải pháp có thể tùy chỉnh và tiết kiệm chi phí.  
+
+## 3. Phần Mềm Này Thay Thế Những Gì?  
+Peppermint là một đối thủ cạnh tranh mạnh mẽ với:  
+- **Zendesk** (Hỗ trợ khách hàng & ticket)  
+- **Jira Service Management** (ITSM & theo dõi vấn đề)  
+- **Freshdesk** (Phần mềm help desk)  
+- **osTicket** (Hệ thống ticket mã nguồn mở)  
+
+## 4. Chức Năng Chính  
+Các tính năng chính của Peppermint bao gồm:  
+✔ **Hệ thống Ticket** – Quản lý yêu cầu khách hàng hiệu quả.  
+✔ **Hỗ trợ Đa Kênh** – Email, biểu mẫu web và tích hợp API.  
+✔ **Kiến thức Nền tảng** – Tài liệu tích hợp cho hỗ trợ tự phục vụ.  
+✔ **Quy trình làm việc Tùy chỉnh** – Tự động hóa phân công ticket và cập nhật trạng thái.  
+✔ **Cộng tác Nhóm** – Ghi chú nội bộ và phân công đại lý.  
+✔ **Tự lưu trữ & Tập trung vào Quyền riêng tư** – Toàn quyền kiểm soát dữ liệu của bạn.  
+✔ **REST API** – Mở rộng chức năng với tích hợp tùy chỉnh.  
+
+## 5. Ưu và Nhược Điểm  
+### **Ưu điểm**  
+✅ **Mã nguồn mở & miễn phí** – Không có chi phí cấp phép.  
+✅ **Tự lưu trữ** – Lý tưởng cho các tổ chức có ý thức về quyền riêng tư.  
+✅ **Nhẹ & nhanh** – Được xây dựng với các framework JavaScript hiện đại.  
+✅ **Có thể tùy chỉnh** – Sửa đổi quy trình làm việc và giao diện khi cần.  
+
+### **Nhược điểm**  
+❌ **Yêu cầu thiết lập kỹ thuật** – Không dễ dàng như các lựa chọn thay thế SaaS.  
+❌ **Cộng đồng nhỏ hơn** – Ít tích hợp bên thứ ba hơn so với Zendesk.  
+❌ **Chưa có ứng dụng di động** – Chỉ dựa trên web.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)  
+### **Yêu cầu**  
+- **Máy chủ Linux (Ubuntu 22.04 được khuyến nghị)**  
+- **Docker & Docker Compose** (Yêu cầu cho triển khai container hóa)  
+- **Node.js (v16+)** (Cho bản dựng phát triển)  
+
+### **Triển khai Từng bước**  
+
+#### **Tùy chọn 1: Docker (Khuyến nghị)**  
+1. **Cài đặt Docker & Docker Compose**  
+   ```bash
+   sudo apt update && sudo apt install docker.io docker-compose -y
+   ```  
+2. **Clone Kho Lưu trữ**  
+   ```bash
+   git clone https://github.com/Peppermint-Lab/peppermint.git
+   cd peppermint
+   ```  
+3. **Cấu hình Môi trường**  
+   Sao chép tệp `.env` mẫu và sửa đổi nó:  
+   ```bash
+   cp .env.example .env
+   nano .env  # Cập nhật cơ sở dữ liệu và cài đặt SMTP
+   ```  
+4. **Khởi động Container**  
+   ```bash
+   docker-compose up -d
+   ```  
+5. **Truy cập Peppermint**  
+   Mở `http://dia-chi-may-chu-cua-ban:3000` trong trình duyệt.  
+
+#### **Tùy chọn 2: Thiết lập Thủ công (Dành cho Nhà phát triển)**  
+1. **Cài đặt Node.js & PostgreSQL**  
+   ```bash
+   curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+   sudo apt install -y nodejs postgresql
+   ```  
+2. **Thiết lập Cơ sở dữ liệu**  
+   ```bash
+   sudo -u postgres psql -c "CREATE DATABASE peppermint;"
+   ```  
+3. **Cài đặt Phụ thuộc & Chạy**  
+   ```bash
+   npm install
+   npm run build
+   npm start
+   ```  
+
+### **Các Bước Sau Cài đặt**  
+- **Tạo tài khoản quản trị** qua giao diện web.  
+- **Cấu hình SMTP** cho thông báo email.  
+- **Thiết lập sao lưu** cho cơ sở dữ liệu PostgreSQL.  
+
+### **Kết Luận**  
+Peppermint là một **giải pháp thay thế mạnh mẽ, tập trung vào quyền riêng tư** cho các giải pháp help desk thương mại. Mặc dù yêu cầu một số thiết lập kỹ thuật, **bản chất mã nguồn mở và các tùy chọn tùy chỉnh** làm cho nó trở thành lựa chọn hấp dẫn cho các nhóm coi trọng quyền kiểm soát và linh hoạt.  
+
+🚀 **Sẵn sàng dùng thử?** Clone kho lưu trữ và triển khai ngay hôm nay!  
+```

--- a/src/content/posts/open-source-crm-WebVella-WebVella-ERP-vi.md
+++ b/src/content/posts/open-source-crm-WebVella-WebVella-ERP-vi.md
@@ -1,0 +1,250 @@
+---
+lang: vi
+title: "WebVella ERP: Đánh Giá Nền Tảng Quản Lý Kinh Doanh Mã Nguồn Mở"
+description: "Đánh giá toàn diện về WebVella ERP - giải pháp ERP và CRM mã nguồn mở, có thể cắm thêm, được xây dựng trên ASP.NET Core 9, RazorPages và PostgreSQL."
+published: 2025-09-23
+tags: ['open-source', 'self-host', 'erp', 'crm', 'aspnet-core', 'postgresql', 'razor-pages', 'business-software']
+category: Self-hosted
+author: minhpt
+---
+
+# WebVella/WebVella-ERP - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Chỉ Số GitHub
+
+- **URL:** [https://github.com/WebVella/WebVella-ERP](https://github.com/WebVella/WebVella-ERP)
+- **Sao:** 1318
+- **Giấy phép:** MIT License
+- **Ngôn ngữ Chính:** C#
+- **Cập nhật Lần cuối:** Phát triển tích cực gần đây
+
+## 2. Mô Tả Dự Án
+
+WebVella ERP là một nền tảng hoạch định nguồn lực doanh nghiệp (ERP) và quản lý quan hệ khách hàng (CRM) toàn diện, miễn phí và mã nguồn mở được xây dựng trên các công nghệ Microsoft hiện đại. Phần mềm được thiết kế với kiến trúc có thể cắm thêm, cho phép doanh nghiệp tùy chỉnh và mở rộng chức năng theo nhu cầu cụ thể. Được xây dựng trên ASP.NET Core 9 và RazorPages, nó cung cấp hiệu suất tuyệt vời và khả năng tương thích đa nền tảng, hỗ trợ cả môi trường lưu trữ Linux và Windows.
+
+Nền tảng sử dụng PostgreSQL làm cơ sở dữ liệu chính, đảm bảo quản lý dữ liệu mạnh mẽ và khả năng mở rộng cho doanh nghiệp ở mọi quy mô. Thiết kế mô-đun cho phép các tổ chức bắt đầu với chức năng cốt lõi và dần dần thêm các mô-đun chuyên biệt khi nhu cầu của họ phát triển.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+WebVella ERP phục vụ như một giải pháp thay thế khả thi cho một số giải pháp quản lý kinh doanh thương mại và mã nguồn mở phổ biến:
+
+**Thay thế ERP/CRM Thương mại:**
+- SAP Business One
+- Microsoft Dynamics 365
+- Oracle NetSuite
+- Salesforce CRM
+- Odoo Enterprise Edition
+
+**Lựa chọn Thay thế Mã nguồn Mở:**
+- ERPNext
+- Dolibarr
+- SuiteCRM
+- Apache OFBiz
+- Tryton
+
+## 4. Chức Năng Chính
+
+WebVella ERP cung cấp một bộ tính năng quản lý kinh doanh toàn diện:
+
+**Mô-đun ERP Cốt lõi:**
+- Quản lý tài chính và kế toán
+- Quản lý hàng tồn kho và chuỗi cung ứng
+- Nhân sự và bảng lương
+- Quản lý và theo dõi dự án
+- Xử lý đơn hàng mua và bán
+
+**Khả năng CRM:**
+- Quản lý liên hệ và khách hàng tiềm năng
+- Theo dõi kênh bán hàng
+- Ticket dịch vụ và hỗ trợ khách hàng
+- Tự động hóa tiếp thị
+- Bảng điều khiển báo cáo và phân tích
+
+**Tính năng Kỹ thuật:**
+- Kiến trúc có thể cắm thêm để phát triển mô-đun tùy chỉnh
+- RESTful API để tích hợp với hệ thống bên thứ ba
+- Kiểm soát truy cập và bảo mật dựa trên vai trò
+- Hỗ trợ đa khách thuê
+- Báo cáo thời gian thực và thông tin kinh doanh
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu điểm:**
+- **Tiết kiệm Chi phí:** Hoàn toàn miễn phí và mã nguồn mở với giấy phép MIT
+- **Công nghệ Hiện đại:** Được xây dựng trên ASP.NET Core 9 cho hiệu suất tối ưu
+- **Đa nền tảng:** Hỗ trợ triển khai cả Linux và Windows
+- **Kiến trúc Mở rộng:** Hệ thống có thể cắm thêm cho phép phát triển mô-đun tùy chỉnh
+- **Backend PostgreSQL:** Hỗ trợ cơ sở dữ liệu cấp doanh nghiệp
+- **Cộng đồng Tích cực:** Cập nhật thường xuyên và hỗ trợ cộng đồng
+- **Tự lưu trữ:** Toàn quyền kiểm soát dữ liệu và quyền riêng tư
+
+**Nhược điểm:**
+- **Đường cong Học tập Dốc hơn:** Yêu cầu kiến thức phát triển .NET để tùy chỉnh
+- **Hệ sinh thái Nhỏ hơn:** Ít mô-đun dựng sẵn hơn so với các giải pháp đã được thiết lập
+- **Khoảng trống Tài liệu:** Một số tính năng nâng cao có thể thiếu tài liệu toàn diện
+- **Tích hợp Bên thứ ba Hạn chế:** Thị trường nhỏ hơn so với các lựa chọn thay thế thương mại
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự lưu trữ)
+
+### Yêu cầu
+- Ubuntu 20.04 LTS trở lên (khuyến nghị)
+- .NET 9.0 SDK hoặc runtime
+- Máy chủ cơ sở dữ liệu PostgreSQL 12+
+- Nginx (cho reverse proxy)
+- Quyền truy cập superuser trên máy chủ
+
+### Cài đặt Từng bước
+
+**1. Chuẩn bị Hệ thống**
+```bash
+# Cập nhật gói hệ thống
+sudo apt update && sudo apt upgrade -y
+
+# Cài đặt các gói cần thiết
+sudo apt install -y curl wget gnupg software-properties-common
+```
+
+**2. Cài đặt .NET 9.0 Runtime**
+```bash
+# Thêm kho lưu trữ gói Microsoft
+wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+# Cài đặt .NET runtime
+sudo apt update
+sudo apt install -y aspnetcore-runtime-9.0
+```
+
+**3. Cài đặt và Cấu hình PostgreSQL**
+```bash
+# Cài đặt PostgreSQL
+sudo apt install -y postgresql postgresql-contrib
+
+# Khởi động và kích hoạt PostgreSQL
+sudo systemctl start postgresql
+sudo systemctl enable postgresql
+
+# Tạo cơ sở dữ liệu và người dùng
+sudo -u postgres psql -c "CREATE DATABASE webvella_erp;"
+sudo -u postgres psql -c "CREATE USER webvella_user WITH PASSWORD 'your_secure_password';"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE webvella_erp TO webvella_user;"
+```
+
+**4. Cài đặt Nginx**
+```bash
+sudo apt install -y nginx
+sudo systemctl start nginx
+sudo systemctl enable nginx
+```
+
+**5. Tải xuống và Cấu hình WebVella ERP**
+```bash
+# Tạo thư mục ứng dụng
+sudo mkdir -p /var/www/webvella-erp
+cd /var/www/webvella-erp
+
+# Tải xuống bản phát hành mới nhất (kiểm tra GitHub cho phiên bản mới nhất)
+sudo wget https://github.com/WebVella/WebVella-ERP/releases/download/vX.X.X/WebVella-ERP.zip
+sudo unzip WebVella-ERP.zip
+
+# Đặt quyền thích hợp
+sudo chown -R www-data:www-data /var/www/webvella-erp
+sudo chmod -R 755 /var/www/webvella-erp
+```
+
+**6. Cấu hình Cài đặt Ứng dụng**
+```bash
+# Chỉnh sửa appsettings.json với cấu hình cơ sở dữ liệu của bạn
+sudo nano /var/www/webvella-erp/appsettings.json
+```
+
+Cập nhật chuỗi kết nối:
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=webvella_erp;Username=webvella_user;Password=your_secure_password"
+  }
+}
+```
+
+**7. Tạo Dịch vụ Systemd**
+```bash
+sudo nano /etc/systemd/system/webvella-erp.service
+```
+
+Thêm nội dung sau:
+```ini
+[Unit]
+Description=WebVella ERP Application
+After=network.target
+
+[Service]
+WorkingDirectory=/var/www/webvella-erp
+ExecStart=/usr/bin/dotnet /var/www/webvella-erp/WebVella.Erp.Web.dll
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+SyslogIdentifier=webvella-erp
+User=www-data
+Environment=ASPNETCORE_ENVIRONMENT=Production
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**8. Cấu hình Reverse Proxy Nginx**
+```bash
+sudo nano /etc/nginx/sites-available/webvella-erp
+```
+
+Thêm cấu hình sau:
+```nginx
+server {
+    listen 80;
+    server_name ten-mien-cua-ban.com;
+
+    location / {
+        proxy_pass http://localhost:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+**9. Các Bước Thiết lập Cuối cùng**
+```bash
+# Kích hoạt Nginx site
+sudo ln -s /etc/nginx/sites-available/webvella-erp /etc/nginx/sites-enabled/
+
+# Kiểm tra cấu hình Nginx
+sudo nginx -t
+
+# Tải lại Nginx
+sudo systemctl reload nginx
+
+# Khởi động dịch vụ WebVella ERP
+sudo systemctl enable webvella-erp
+sudo systemctl start webvella-erp
+
+# Kiểm tra trạng thái dịch vụ
+sudo systemctl status webvella-erp
+```
+
+**10. Thiết lập Ban đầu**
+- Mở trình duyệt web và điều hướng đến IP hoặc tên miền máy chủ của bạn
+- Làm theo trình hướng dẫn thiết lập ban đầu để cấu hình thông tin đăng nhập quản trị
+- Thiết lập thông tin tổ chức của bạn và các mô-đun ban đầu
+
+### Mẹo Khắc phục Sự cố
+- Kiểm tra nhật ký: `sudo journalctl -u webvella-erp -f`
+- Xác minh kết nối cơ sở dữ liệu: `sudo -u postgres psql -d webvella_erp`
+- Đảm bảo tường lửa cho phép lưu lượng HTTP/HTTPS
+- Xác minh quyền tệp trong thư mục ứng dụng
+
+Phiên bản WebVella ERP của bạn bây giờ sẽ chạy và có thể truy cập qua trình duyệt web. Nền tảng cung cấp tài liệu mở rộng để tùy chỉnh thêm và phát triển mô-đun.

--- a/src/content/posts/open-source-crm-asyraffff-Open-Source-Ruby-and-Rails-Apps-vi.md
+++ b/src/content/posts/open-source-crm-asyraffff-Open-Source-Ruby-and-Rails-Apps-vi.md
@@ -1,0 +1,231 @@
+---
+lang: vi
+title: "Các Ứng Dụng Ruby và Rails Mã Nguồn Mở: Bộ Sưu Tập Toàn Diện Cho Lập Trình Viên"
+description: "Khám phá danh sách tuyển chọn các ứng dụng Ruby và Rails mã nguồn mở từ asyraffff. Hoàn hảo cho lập trình viên muốn học hỏi, đóng góp, hoặc tìm giải pháp thay thế cho phần mềm thương mại."
+published: 2025-09-23
+tags: ['open-source', 'self-host', 'ruby', 'rails', 'ruby-on-rails', 'web-development', 'programming']
+category: Self-hosted
+author: minhpt
+---
+
+# asyraffff/Open-Source-Ruby-and-Rails-Apps - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/asyraffff/Open-Source-Ruby-and-Rails-Apps](https://github.com/asyraffff/Open-Source-Ruby-and-Rails-Apps)
+- **Số sao:** 1153
+
+## 2. Mô Tả Dự Án
+
+`asyraffff/Open-Source-Ruby-and-Rails-Apps` là một bộ sưu tập được tuyển chọn tỉ mỉ các ứng dụng mã nguồn mở được xây dựng bằng Ruby và Ruby on Rails. Kho lưu trữ này đóng vai trò là trung tâm tài nguyên quý giá cho lập trình viên, sinh viên và tổ chức muốn khám phá các ứng dụng Ruby/Rails thực tế. Bộ sưu tập trải dài nhiều danh mục bao gồm nền tảng thương mại điện tử, hệ thống quản lý nội dung, công cụ quản lý dự án và ứng dụng mạng xã hội.
+
+Kho lưu trữ này hoạt động như cả tài nguyên học tập và tài liệu tham khảo thực tế cho lập trình viên muốn hiểu các mẫu Rails, quyết định kiến trúc và phương pháp hay nhất thông qua việc nghiên cứu các ứng dụng sẵn sàng sản xuất.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Bộ sưu tập này cung cấp các giải pháp thay thế mã nguồn mở cho nhiều phần mềm thương mại:
+
+**Giải Pháp Thương Mại Điện Tử:**
+- Shopify (với các ứng dụng dựa trên Solidus/Spree)
+- Các giải pháp thay thế BigCommerce
+- Nền tảng thương mại điện tử tùy chỉnh
+
+**Quản Lý Nội Dung:**
+- Giải pháp thay thế WordPress (CMS dựa trên Rails)
+- Nền tảng xuất bản kiểu Medium
+- Công cụ blog tùy chỉnh
+
+**Quản Lý Dự Án:**
+- Giải pháp thay thế Trello (bảng kanban dựa trên Rails)
+- Công cụ quản lý dự án kiểu Basecamp
+- Hệ thống theo dõi vấn đề
+
+**Mạng Xã Hội:**
+- Giải pháp thay thế nền tảng mạng xã hội cơ bản
+- Phần mềm diễn đàn cộng đồng
+- Nền tảng thảo luận
+
+**Ứng Dụng Kinh Doanh:**
+- Hệ thống CRM
+- Giải pháp ERP
+- Phần mềm kế toán
+
+## 4. Chức Năng Cốt Lõi
+
+Kho lưu trữ không cung cấp một ứng dụng đơn lẻ mà thu thập nhiều dự án mã nguồn mở với các chức năng đa dạng:
+
+**Tính Năng Bộ Sưu Tập:**
+- Danh sách phân loại các ứng dụng Ruby/Rails
+- Cập nhật thường xuyên và bổ sung mới
+- Quy trình lọc và kiểm duyệt chất lượng
+- Mô tả và liên kết dự án chi tiết
+
+**Loại Ứng Dụng Bao Gồm:**
+- Ứng dụng web full-stack
+- Dự án Rails chỉ API
+- Kiến trúc monolithic
+- Kiến trúc microservices
+- Ứng dụng Rails 7+ hiện đại với Hotwire/Stimulus
+- Ứng dụng Rails cũ cho mục đích giáo dục
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu Điểm
+
+**Bộ Sưu Tập Toàn Diện:**
+- Nhiều loại ứng dụng và cấp độ phức tạp
+- Thường xuyên cập nhật với các dự án mới và phù hợp
+- Bao gồm cả ứng dụng thân thiện với người mới bắt đầu và nâng cao
+
+**Giá Trị Giáo Dục:**
+- Tài nguyên học tập tuyệt vời cho các mẫu Rails
+- Ví dụ mã nguồn và kiến trúc thực tế
+- Cơ hội nghiên cứu các phương pháp triển khai khác nhau
+
+**Cộng Đồng:**
+- Bảo trì tích cực và đóng góp từ cộng đồng
+- Kiểm soát chất lượng qua xếp hạng sao và phản hồi cộng đồng
+- Hữu ích để tìm cảm hứng và phương pháp hay nhất
+
+**Tiện Ích Thực Tế:**
+- Nguồn tìm giải pháp mã nguồn mở sẵn sàng sử dụng
+- Cơ sở để bắt đầu dự án mới hoặc tính năng mới
+- Tài liệu tham khảo cho quyết định kiến trúc
+
+### Nhược Điểm
+
+**Chất Lượng Đa Dạng:**
+- Chất lượng ứng dụng và tình trạng bảo trì khác nhau đáng kể
+- Một số dự án có thể lỗi thời hoặc bị bỏ rơi
+- Tiêu chuẩn mã hóa không nhất quán giữa các dự án
+
+**Không Có Cài Đặt Thống Nhất:**
+- Mỗi ứng dụng có yêu cầu cài đặt riêng
+- Không có quy trình triển khai tiêu chuẩn hóa
+- Yêu cầu đánh giá riêng từng dự án
+
+**Chi Phí Bảo Trì:**
+- Theo dõi cập nhật qua nhiều dự án
+- Rủi ro bảo mật tiềm ẩn với các dự án không được bảo trì
+- Chất lượng tài liệu khác nhau giữa các ứng dụng
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+
+Vì đây là kho lưu trữ bộ sưu tập chứ không phải một ứng dụng đơn lẻ, đây là hướng dẫn chung để làm việc với các ứng dụng Ruby on Rails từ bộ sưu tập này:
+
+### Yêu Cầu Tiên Quyết
+
+**Yêu Cầu Hệ Thống:**
+- Ubuntu 20.04 LTS trở lên
+- RAM tối thiểu 2GB (khuyến nghị 4GB)
+- 20GB dung lượng ổ đĩa trống
+
+**Phần Mềm Cần Thiết:**
+```bash
+# Cập nhật hệ thống
+sudo apt update && sudo apt upgrade -y
+
+# Cài đặt các gói thiết yếu
+sudo apt install -y curl git build-essential libssl-dev libreadline-dev zlib1g-dev
+
+# Cài đặt Ruby bằng rbenv
+git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+source ~/.bashrc
+
+# Cài đặt plugin ruby-build
+git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+# Cài đặt Ruby (phiên bản ổn định mới nhất)
+rbenv install 3.2.2
+rbenv global 3.2.2
+
+# Cài đặt Rails
+gem install rails -v 7.0.8
+
+# Cài đặt Node.js và Yarn (cho asset pipeline)
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt install -y nodejs
+npm install -g yarn
+
+# Cài đặt PostgreSQL (lựa chọn cơ sở dữ liệu phổ biến)
+sudo apt install -y postgresql postgresql-contrib libpq-dev
+```
+
+### Quy Trình Thiết Lập Ứng Dụng
+
+**1. Chọn Một Ứng Dụng:**
+```bash
+# Duyệt kho lưu trữ và chọn ứng dụng
+# Clone ứng dụng đã chọn
+git clone [đường-dẫn-kho-lưu-trữ-ứng-dụng]
+cd [thư-mục-ứng-dụng]
+```
+
+**2. Thiết Lập Cơ Sở Dữ Liệu:**
+```bash
+# Tạo người dùng cơ sở dữ liệu (nếu dùng PostgreSQL)
+sudo -u postgres createuser -s [tên_người_dùng]
+sudo -u postgres psql -c "ALTER USER [tên_người_dùng] WITH PASSWORD 'mật_khẩu_của_bạn';"
+
+# Cài đặt phụ thuộc
+bundle install
+yarn install
+
+# Thiết lập cơ sở dữ liệu
+rails db:create
+rails db:migrate
+rails db:seed  # nếu có dữ liệu seed
+```
+
+**3. Cấu Hình Môi Trường:**
+```bash
+# Sao chép mẫu môi trường
+cp .env.example .env
+# Chỉnh sửa file .env với cấu hình của bạn
+nano .env
+```
+
+**4. Kiểm Tra Ứng Dụng:**
+```bash
+# Chạy kiểm thử (nếu có)
+rails test
+
+# Khởi động máy chủ phát triển
+rails server
+```
+
+**5. Triển Khai Sản Xuất (Cơ Bản):**
+```bash
+# Biên dịch trước tài sản
+RAILS_ENV=production rails assets:precompile
+
+# Thiết lập cơ sở dữ liệu sản xuất
+RAILS_ENV=production rails db:create db:migrate
+
+# Khởi động máy chủ sản xuất (dùng Puma)
+RAILS_ENV=production bundle exec puma
+```
+
+### Giải Pháp Docker (Nếu Có)
+
+Nhiều ứng dụng Rails hiện đại hỗ trợ Docker:
+
+```bash
+# Nếu có Dockerfile
+docker build -t rails-app .
+docker run -p 3000:3000 rails-app
+
+# Hoặc dùng docker-compose
+docker-compose up
+```
+
+### Lưu Ý Quan Trọng
+
+- Luôn kiểm tra README cụ thể của từng ứng dụng để biết yêu cầu riêng
+- Xem xét giấy phép của ứng dụng trước khi sử dụng trong sản xuất
+- Cân nhắc các vấn đề bảo mật và cập nhật phụ thuộc thường xuyên
+- Giám sát nhật ký ứng dụng và chỉ số hiệu suất trong sản xuất
+
+Bộ sưu tập này cung cấp điểm khởi đầu tuyệt vời cho nhiều dự án khác nhau, nhưng mỗi ứng dụng yêu cầu đánh giá và tùy chỉnh riêng cho mục đích sản xuất.

--- a/src/content/posts/open-source-crm-dwijitsolutions-laraadmin-vi.md
+++ b/src/content/posts/open-source-crm-dwijitsolutions-laraadmin-vi.md
@@ -1,0 +1,148 @@
+---
+lang: vi
+title: "LaraAdmin: Giải Pháp Bảng Quản Trị Laravel & CMS Mã Nguồn Mở Tối Ưu"
+description: "Đánh giá toàn diện về dwijitsolutions/laraadmin - bảng quản trị Laravel mã nguồn mở với tính năng tạo CRUD, quản lý module và khả năng tự lưu trữ."
+published: 2025-08-22
+tags: ['open-source', 'self-host', 'laravel', 'admin-panel', 'cms', 'php', 'mysql']
+category: Self-hosted
+author: minhpt
+---
+
+# dwijitsolutions/laraadmin - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/dwijitsolutions/laraadmin](https://github.com/dwijitsolutions/laraadmin)
+- **Số sao:** 1582
+- **Giấy phép:** MIT License
+- **Cập nhật lần cuối:** Tháng 8, 2024
+
+## 2. Mô Tả Dự Án
+
+LaraAdmin là một hệ thống bảng quản trị và quản lý nội dung mã nguồn mở toàn diện dựa trên Laravel, được thiết kế để tăng tốc phát triển backend. Nó phục vụ như một giải pháp linh hoạt để tạo backend quản trị, công cụ quản lý dữ liệu hoặc boilerplate CRM. Được xây dựng trên framework Laravel mạnh mẽ, nó cung cấp cho lập trình viên nền tảng vững chắc để xây dựng các ứng dụng cấp doanh nghiệp với thời gian thiết lập tối thiểu.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+LaraAdmin cạnh tranh và có thể thay thế nhiều giải pháp thương mại và mã nguồn mở bao gồm:
+
+- **Bảng Quản Trị Thương Mại:** Laravel Nova, Backpack for Laravel
+- **Giải Pháp Thay Thế Mã Nguồn Mở:** Voyager, Orchid Platform, Filament Admin
+- **CMS Truyền Thống:** WordPress admin cho các ứng dụng Laravel tùy chỉnh
+- **Bảng Quản Trị Tự Xây Dựng:** Loại bỏ nhu cầu xây dựng giao diện quản trị từ đầu
+
+## 4. Chức Năng Cốt Lõi
+
+LaraAdmin cung cấp bộ tính năng phong phú:
+
+- **Tạo CRUD Nâng Cao:** Tự động tạo giao diện Thêm, Sửa, Xóa cho các model cơ sở dữ liệu
+- **Quản Lý Module:** Tạo và quản lý module tùy chỉnh qua giao diện trực quan
+- **Kiểm Soát Truy Cập Dựa Trên Vai Trò:** Hệ thống quản lý quyền người dùng toàn diện
+- **Sao Lưu Cơ Sở Dữ Liệu:** Tính năng sao lưu và phục hồi cơ sở dữ liệu tích hợp
+- **Quản Lý File:** Quản lý file tích hợp với hỗ trợ nhiều trình điều khiển lưu trữ
+- **Hỗ Trợ Giao Diện:** Giao diện quản trị có thể tùy chỉnh với nhiều tùy chọn chủ đề
+- **Sẵn Sàng API:** Điểm cuối RESTful API cho tất cả dữ liệu được quản lý
+- **Hỗ Trợ Migration:** Quản lý lược đồ cơ sở dữ liệu qua Laravel migrations
+
+## 5. Ưu và Nhược Điểm
+
+### Ưu Điểm:
+- **Mã Nguồn Mở & Miễn Phí:** Được cấp phép MIT với hỗ trợ cộng đồng tích cực
+- **Tích Hợp Laravel:** Tích hợp liền mạch với hệ sinh thái Laravel
+- **Tiết Kiệm Thời Gian:** Phát triển ứng dụng nhanh chóng với tạo CRUD tự động
+- **Có Thể Mở Rộng:** Kiến trúc module cho phép tùy chỉnh và mở rộng dễ dàng
+- **Tài Liệu Toàn Diện:** Được ghi chép đầy đủ với ví dụ và hướng dẫn
+
+### Nhược Điểm:
+- **Đường Cong Học Tập:** Yêu cầu kiến thức cơ bản về Laravel để tùy chỉnh
+- **Tốn Nhiều Tài Nguyên:** Có thể yêu cầu nhiều tài nguyên máy chủ hơn so với các giải pháp tối thiểu
+- **Giao Diện Người Dùng Hạn Chế:** Chủ yếu tập trung vào quản trị backend
+- **Phụ Thuộc Nhiều:** Dựa trên nhiều gói và phụ thuộc Laravel
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+
+### Yêu Cầu Tiên Quyết:
+- Máy chủ Ubuntu 20.04/22.04 LTS
+- PHP 8.1 trở lên
+- Composer 2.0+
+- MySQL 8.0+ hoặc MariaDB 10.4+
+- Node.js 16+ và npm
+- Git
+
+### Cài Đặt Từng Bước:
+
+```bash
+# Cập nhật gói hệ thống
+sudo apt update && sudo apt upgrade -y
+
+# Cài đặt các gói cần thiết
+sudo apt install -y php php-cli php-fpm php-json php-common php-mysql php-zip php-gd php-mbstring php-curl php-xml php-bcmath php-tokenizer
+
+# Cài đặt Composer
+curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+
+# Cài đặt Node.js
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Tạo cơ sở dữ liệu
+sudo mysql -u root -p
+CREATE DATABASE laraadmin;
+CREATE USER 'laraadmin'@'localhost' IDENTIFIED BY 'mật_khẩu_bảo_mật_của_bạn';
+GRANT ALL PRIVILEGES ON laraadmin.* TO 'laraadmin'@'localhost';
+FLUSH PRIVILEGES;
+EXIT;
+
+# Clone kho lưu trữ
+git clone https://github.com/dwijitsolutions/laraadmin.git
+cd laraadmin
+
+# Cài đặt phụ thuộc PHP
+composer install
+
+# Cài đặt phụ thuộc Node
+npm install
+
+# Cấu hình môi trường
+cp .env.example .env
+nano .env
+
+# Cập nhật biến môi trường:
+DB_DATABASE=laraadmin
+DB_USERNAME=laraadmin
+DB_PASSWORD=mật_khẩu_bảo_mật_của_bạn
+
+# Tạo khóa ứng dụng
+php artisan key:generate
+
+# Chạy migrations
+php artisan migrate
+
+# Cài đặt LaraAdmin
+php artisan laraadmin:install
+
+# Xây dựng tài sản
+npm run dev
+
+# Thiết lập quyền thích hợp
+sudo chown -R www-data:www-data storage bootstrap/cache
+sudo chmod -R 775 storage bootstrap/cache
+
+# Cấu hình máy chủ web (ví dụ Nginx)
+sudo nano /etc/nginx/sites-available/laraadmin
+
+# Khởi động ứng dụng
+php artisan serve
+```
+
+### Sau Khi Cài Đặt:
+1. Truy cập ứng dụng tại `http://địa-chỉ-máy-chủ-của-bạn:8000`
+2. Hoàn thành trình hướng dẫn thiết lập
+3. Tạo người dùng quản trị đầu tiên
+4. Cấu hình module và quyền của bạn
+
+### Bảo Trì:
+- Sao lưu thường xuyên: Sử dụng tính năng sao lưu tích hợp hoặc thiết lập cron jobs
+- Cập nhật bảo mật: Thường xuyên cập nhật Laravel và các phụ thuộc
+- Giám sát hiệu suất: Triển khai giám sát cho hiệu suất cơ sở dữ liệu và ứng dụng
+
+LaraAdmin cung cấp nền tảng tuyệt vời để xây dựng các bảng quản trị tinh vi trong khi vẫn duy trì tính linh hoạt và sức mạnh của framework Laravel.

--- a/src/content/posts/open-source-crm-espocrm-espocrm-vi.md
+++ b/src/content/posts/open-source-crm-espocrm-espocrm-vi.md
@@ -1,0 +1,130 @@
+---
+lang: vi
+title: "Đánh Giá EspoCRM – Giải Pháp CRM Mã Nguồn Mở Mạnh Mẽ"
+description: "Khám phá EspoCRM, giải pháp CRM mã nguồn mở, tự lưu trữ có thể cạnh tranh với các nền tảng thương mại. Tìm hiểu tính năng, ưu & nhược điểm, và cách cài đặt."
+published: 2025-08-19
+tags: ['open-source', 'self-host', 'crm', 'php', 'mysql', 'business-software']
+category: 'Self-hosted'
+author: minhpt
+---
+
+# espocrm/espocrm - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+- **URL:** [https://github.com/espocrm/espocrm](https://github.com/espocrm/espocrm)  
+- **Số sao:** 2171  
+- **Giấy phép:** GNU GPL v3  
+- **Phiên bản mới nhất:** v8.1.0  
+
+EspoCRM là một nền tảng Quản lý Quan hệ Khách hàng (CRM) mã nguồn mở linh hoạt, được thiết kế cho các doanh nghiệp tìm kiếm giải pháp thay thế tự lưu trữ cho các giải pháp thương mại như Salesforce hay HubSpot.
+
+## 2. Mô Tả Dự Án
+EspoCRM là một **CRM dựa trên PHP** giúp doanh nghiệp quản lý tương tác khách hàng, quy trình bán hàng, chiến dịch tiếp thị và vé hỗ trợ. Nó cung cấp **giao diện hiện đại**, **REST API** và **module có thể tùy chỉnh**, phù hợp cho doanh nghiệp vừa và nhỏ (SMEs).  
+
+Các khía cạnh chính:  
+✔ **Tự lưu trữ** (không bị khóa nhà cung cấp)  
+✔ **Có thể mở rộng** qua module và tích hợp  
+✔ **Giao diện thân thiện với di động**  
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+EspoCRM cạnh tranh với:  
+- **Salesforce** (Thương mại)  
+- **HubSpot CRM** (Freemium)  
+- **SuiteCRM** (Fork mã nguồn mở của SugarCRM)  
+- **Zoho CRM** (Dựa trên SaaS)  
+
+Không giống các giải pháp SaaS, EspoCRM cho người dùng toàn quyền kiểm soát dữ liệu của họ.
+
+## 4. Chức Năng Cốt Lõi
+- **Quản Lý Liên Hệ & Tài Khoản** – Lưu trữ chi tiết khách hàng, tương tác và tài liệu.  
+- **Quy Trình Bán Hàng** – Theo dõi khách hàng tiềm năng, cơ hội và giao dịch.  
+- **Tích Hợp Email** – Đồng bộ với IMAP/POP3, gửi email hàng loạt.  
+- **Nhiệm Vụ & Lịch** – Lên lịch cuộc họp và theo dõi.  
+- **Báo Cáo & Bảng Điều Khiển** – Trực quan hóa hiệu suất bán hàng.  
+- **API & Webhooks** – Tích hợp với công cụ bên thứ ba.  
+
+## 5. Ưu và Nhược Điểm
+### **Ưu Điểm**  
+✅ **Không Có Chi Phí Cấp Phép** – Miễn phí và mã nguồn mở.  
+✅ **Có Thể Tùy Chỉnh** – Sửa đổi trường, quy trình làm việc và bố cục.  
+✅ **Quyền Riêng Tư Tự Lưu Trữ** – Dữ liệu ở lại trên máy chủ của bạn.  
+✅ **Cộng Đồng Tích Cực** – Cập nhật thường xuyên và plugin.  
+
+### **Nhược Điểm**  
+❌ **Yêu Cầu Thiết Lập Kỹ Thuật** – Cần kiến thức PHP/MySQL.  
+❌ **Lưu Trữ Đám Mây Hạn Chế** – Không tối ưu cho triển khai serverless.  
+❌ **Ít Tích Hợp Gốc Hơn** So với CRM SaaS.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+### **Yêu Cầu Tiên Quyết**  
+- **Máy Chủ Linux** (Khuyến nghị Ubuntu 22.04)  
+- **PHP 8.1+** (với `php-mysql`, `php-curl`, `php-gd`)  
+- **MySQL 5.7+** hoặc **MariaDB 10.3+**  
+- **Apache/Nginx** (với `mod_rewrite` được bật)  
+- **Composer** (để quản lý phụ thuộc)  
+
+### **Thiết Lập Từng Bước**  
+1. **Cài Đặt Phụ Thuộc**  
+   ```bash
+   sudo apt update && sudo apt install -y apache2 mysql-server php php-mysql php-curl php-gd php-zip unzip composer
+   ```
+
+2. **Cấu Hình MySQL**  
+   ```bash
+   sudo mysql_secure_installation
+   mysql -u root -p
+   CREATE DATABASE espocrm;
+   CREATE USER 'espocrm'@'localhost' IDENTIFIED BY 'mật_khẩu_của_bạn';
+   GRANT ALL PRIVILEGES ON espocrm.* TO 'espocrm'@'localhost';
+   FLUSH PRIVILEGES;
+   ```
+
+3. **Tải EspoCRM**  
+   ```bash
+   cd /var/www/html
+   sudo wget https://www.espocrm.com/downloads/EspoCRM-latest.zip
+   sudo unzip EspoCRM-latest.zip
+   sudo chown -R www-data:www-data espocrm/
+   ```
+
+4. **Thiết Lập Apache Virtual Host**  
+   Chỉnh sửa `/etc/apache2/sites-available/espocrm.conf`:  
+   ```apache
+   <VirtualHost *:80>
+       ServerName yourdomain.com
+       DocumentRoot /var/www/html/espocrm
+       <Directory /var/www/html/espocrm>
+           Options Indexes FollowSymLinks
+           AllowOverride All
+           Require all granted
+       </Directory>
+   </VirtualHost>
+   ```
+   Kích hoạt site:  
+   ```bash
+   sudo a2ensite espocrm.conf
+   sudo systemctl restart apache2
+   ```
+
+5. **Chạy Trình Cài Đặt**  
+   Truy cập `http://yourdomain.com` trong trình duyệt và làm theo trình hướng dẫn.  
+
+### **Sau Khi Cài Đặt**  
+- Bảo mật với HTTPS (dùng Let's Encrypt).  
+- Thiết lập cron jobs cho các tác vụ định kỳ:  
+  ```bash
+  * * * * * /usr/bin/php /var/www/html/espocrm/cron.php > /dev/null 2>&1
+  ```
+
+### **Giải Pháp Docker**  
+Cho người dùng Docker, EspoCRM cung cấp image chính thức:  
+```bash
+docker run -d --name espocrm -p 80:80 -v espocrm_data:/var/www/html espocrm/espocrm:latest
+```
+
+---
+
+**Kết Luận**  
+EspoCRM là một CRM mạnh mẽ, tiết kiệm chi phí cho các doanh nghiệp ưu tiên quyền sở hữu dữ liệu. Mặc dù yêu cầu thiết lập thủ công, tính linh hoạt và bản chất mã nguồn mở khiến nó trở thành lựa chọn hấp dẫn.  
+
+**Đóng góp:** Phát hiện lỗi? Gửi issue hoặc PR trên [GitHub](https://github.com/espocrm/espocrm).  

--- a/src/content/posts/open-source-crm-frappe-crm-vi.md
+++ b/src/content/posts/open-source-crm-frappe-crm-vi.md
@@ -1,0 +1,184 @@
+---
+lang: vi
+title: "Frappe CRM: Đánh Giá Toàn Diện Về Giải Pháp CRM Mã Nguồn Mở"
+description: "Khám phá Frappe CRM, hệ thống CRM mã nguồn mở đầy đủ tính năng được xây dựng trên Frappe Framework. Tìm hiểu về tính năng, cài đặt và cách nó so sánh với các giải pháp thương mại."
+published: 2025-08-23
+tags: ['open-source', 'self-host', 'crm', 'frappe-framework', 'python', 'javascript', 'business-automation']
+category: Self-hosted
+author: minhpt
+---
+
+# frappe/crm - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/frappe/crm](https://github.com/frappe/crm)
+- **Số sao:** 1319
+- **Giấy phép:** GNU General Public License v3.0
+- **Ngôn ngữ chính:** JavaScript (56.1%), Python (41.3%)
+- **Cập nhật lần cuối:** Tháng 8, 2025
+
+## 2. Mô Tả Dự Án
+
+Frappe CRM là một hệ thống quản lý quan hệ khách hàng hiện đại, đầy đủ tính năng được xây dựng trên Frappe Framework. Nó được thiết kế để giúp doanh nghiệp quản lý quy trình bán hàng, tương tác khách hàng và chiến dịch tiếp thị trong một nền tảng tích hợp duy nhất. Không giống nhiều CRM thương mại, Frappe CRM cung cấp sự minh bạch hoàn toàn và khả năng tùy chỉnh trong khi vẫn duy trì chức năng cấp doanh nghiệp.
+
+Nền tảng theo kiến trúc module, cho phép doanh nghiệp bắt đầu với các tính năng CRM thiết yếu và mở rộng chức năng khi cần. Nó tích hợp liền mạch với các ứng dụng Frappe khác, đặc biệt là ERPNext, khiến nó trở thành lựa chọn tuyệt vời cho các doanh nghiệp tìm kiếm bộ quản lý kinh doanh toàn diện.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Frappe CRM phục vụ như một giải pháp thay thế hấp dẫn cho nhiều giải pháp CRM phổ biến:
+
+**Giải Pháp Thương Mại:**
+- Salesforce Sales Cloud
+- HubSpot CRM (Gói Premium)
+- Zoho CRM
+- Microsoft Dynamics 365 Sales
+
+**Giải Pháp Mã Nguồn Mở:**
+- SuiteCRM
+- Odoo CRM
+- Vtiger CRM
+- EspoCRM
+
+## 4. Chức Năng Cốt Lõi
+
+Frappe CRM cung cấp khả năng CRM toàn diện bao gồm:
+
+**Quản Lý Quy Trình Bán Hàng:**
+- Bảng quy trình trực quan với chức năng kéo thả
+- Các giai đoạn giao dịch có thể tùy chỉnh và theo dõi xác suất
+- Chấm điểm và định tuyến khách hàng tiềm năng tự động
+
+**Quản Lý Khách Hàng:**
+- Góc nhìn khách hàng 360 độ với lịch sử tương tác
+- Quản lý liên hệ với tích hợp mạng xã hội
+- Hệ thống phân cấp tổ chức và ánh xạ mối quan hệ
+
+**Tự Động Hóa Tiếp Thị:**
+- Quản lý chiến dịch email
+- Biểu mẫu thu thập khách hàng tiềm năng và trang đích
+- Phân tích tiếp thị và theo dõi ROI
+
+**Công Cụ Giao Tiếp:**
+- Đồng bộ email và lịch tích hợp
+- Ghi lại cuộc gọi và tích hợp ghi âm
+- Lên lịch họp và nhắc nhở theo dõi
+
+**Phân Tích và Báo Cáo:**
+- Bảng điều khiển và báo cáo có thể tùy chỉnh
+- Chỉ số hiệu suất bán hàng
+- Dự báo quy trình và phân tích xu hướng
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu Điểm:**
+- ✅ Hoàn toàn miễn phí và mã nguồn mở
+- ✅ Tùy chọn tự lưu trữ đảm bảo quyền riêng tư dữ liệu
+- ✅ Khả năng tùy chỉnh mở rộng
+- ✅ Tích hợp mạnh mẽ với hệ sinh thái Frappe/ERPNext
+- ✅ Giao diện người dùng hiện đại, đáp ứng
+- ✅ Cộng đồng tích cực và cập nhật thường xuyên
+- ✅ Hỗ trợ đa tiền tệ và đa ngôn ngữ
+
+**Nhược Điểm:**
+- ❌ Yêu cầu chuyên môn kỹ thuật để tự lưu trữ
+- ❌ Hệ sinh thái tích hợp bên thứ ba nhỏ hơn so với các lựa chọn thương mại
+- ❌ Hỗ trợ chính thức hạn chế so với giải pháp doanh nghiệp
+- ❌ Đường cong học tập dốc hơn cho người dùng không chuyên kỹ thuật
+- ❌ Chức năng ứng dụng di động hạn chế hơn phiên bản desktop
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+
+### Yêu Cầu Tiên Quyết
+- Ubuntu 20.04 LTS trở lên
+- RAM tối thiểu 4GB (khuyến nghị 8GB cho sản xuất)
+- Tối thiểu 2 lõi CPU
+- 40GB dung lượng ổ đĩa trống
+- Python 3.10+
+- Node.js 16+
+- Redis server
+- MariaDB 10.6+
+
+### Cài Đặt Từng Bước
+
+**1. Cập Nhật Hệ Thống và Cài Đặt Phụ Thuộc**
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install python3-dev python3-setuptools python3-pip \
+python3-venv git curl software-properties-common \
+mariadb-server mariadb-client redis-server
+```
+
+**2. Cài Đặt Node.js và Yarn**
+```bash
+curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo npm install -g yarn
+```
+
+**3. Cấu Hình MariaDB**
+```bash
+sudo mysql_secure_installation
+# Tạo người dùng cơ sở dữ liệu và cơ sở dữ liệu
+sudo mysql -u root -p
+```
+
+Trong MySQL prompt:
+```sql
+CREATE DATABASE frappe_crm;
+CREATE USER 'frappeuser'@'localhost' IDENTIFIED BY 'mật_khẩu_bảo_mật_của_bạn';
+GRANT ALL PRIVILEGES ON frappe_crm.* TO 'frappeuser'@'localhost';
+FLUSH PRIVILEGES;
+EXIT;
+```
+
+**4. Cài Đặt Bench (Frappe Framework CLI)**
+```bash
+sudo -H pip3 install frappe-bench
+```
+
+**5. Khởi Tạo Thư Mục Bench**
+```bash
+bench init frappe-bench --python python3
+cd frappe-bench
+```
+
+**6. Tạo Site Mới**
+```bash
+bench new-site frappe-crm.local \
+--mariadb-root-password mật_khẩu_root_mysql_của_bạn \
+--admin-password mật_khẩu_admin
+```
+
+**7. Cài Đặt Frappe CRM**
+```bash
+bench get-app crm https://github.com/frappe/crm
+bench --site frappe-crm.local install-app crm
+```
+
+**8. Khởi Động Máy Chủ Phát Triển**
+```bash
+bench start
+```
+
+**9. Triển Khai Sản Xuất (Tùy Chọn)**
+Cho triển khai sản xuất, thiết lập:
+```bash
+bench setup production minhpt
+sudo supervisorctl restart all
+sudo bench setup nginx
+sudo systemctl restart nginx
+```
+
+### Mẹo Cấu Hình
+- Thiết lập chứng chỉ SSL bằng Let's Encrypt
+- Cấu hình sao lưu thường xuyên bằng `bench backup`
+- Thiết lập máy chủ email cho thông báo
+- Cấu hình tên miền và cài đặt DNS
+
+### Bảo Trì
+- Cập nhật thường xuyên: `bench update`
+- Quản lý sao lưu: `bench backup`
+- Giám sát hiệu suất bằng công cụ giám sát tích hợp
+
+Frappe CRM cung cấp giải pháp CRM mạnh mẽ, sẵn sàng cho doanh nghiệp, kết hợp tính linh hoạt của mã nguồn mở với các tính năng chuyên nghiệp. Khả năng tự lưu trữ khiến nó đặc biệt hấp dẫn cho các tổ chức quan tâm đến quyền kiểm soát dữ liệu và yêu cầu tùy chỉnh.

--- a/src/content/posts/open-source-crm-frappe-erpnext-vi.md
+++ b/src/content/posts/open-source-crm-frappe-erpnext-vi.md
@@ -1,0 +1,158 @@
+---
+lang: vi
+title: "Frappe/ERPNext - Hệ Thống ERP Mã Nguồn Mở Miễn Phí Cho Doanh Nghiệp"
+description: "Khám phá Frappe/ERPNext, giải pháp ERP mã nguồn mở mạnh mẽ có thể cạnh tranh với các giải pháp thương mại. Tìm hiểu tính năng, ưu nhược điểm và cách tự lưu trữ."
+published: 2025-08-28
+tags: ['open-source', 'self-host', 'erp', 'business-software', 'python', 'frappe']
+category: Self-hosted
+author: minhpt
+---
+
+# frappe/erpnext - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/frappe/erpnext](https://github.com/frappe/erpnext)  
+- **Số sao:** 24,801 (tính đến tháng 11/2023)  
+- **Giấy phép:** GNU General Public License v3.0  
+
+Frappe/ERPNext là một trong những hệ thống **Hoạch định Nguồn lực Doanh nghiệp (ERP)** mã nguồn mở phổ biến nhất hiện nay. Được xây dựng trên Frappe framework, nó cung cấp giải pháp hiện đại, dạng module và có khả năng tùy chỉnh cao cho doanh nghiệp ở mọi quy mô.
+
+## 2. Mô Tả Dự Án
+
+ERPNext là một **ERP mã nguồn mở và miễn phí** được thiết kế để hợp lý hóa hoạt động kinh doanh bằng cách tích hợp các module như:
+
+- **Kế toán & Tài chính**  
+- **Hàng tồn kho & Sản xuất**  
+- **Nhân sự (HR)**  
+- **Quản lý Quan hệ Khách hàng (CRM)**  
+- **Quản lý Dự án**  
+- **Thương mại điện tử & Điểm bán hàng (POS)**  
+
+Nó được xây dựng bằng **Python (Backend)** và **JavaScript (Frontend)** và tuân theo kiến trúc **Model-View-Controller (MVC)**. Frappe framework cho phép lập trình viên mở rộng và tùy chỉnh ERPNext một cách dễ dàng.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+ERPNext phục vụ như một **giải pháp thay thế tiết kiệm chi phí** cho các giải pháp ERP độc quyền như:
+
+- **SAP Business One**  
+- **Oracle NetSuite**  
+- **Microsoft Dynamics 365**  
+- **Odoo (Giải Pháp Thay Thế Mã Nguồn Mở)**  
+
+Đối với doanh nghiệp vừa và nhỏ (SMBs), ERPNext loại bỏ sự phụ thuộc vào nhà cung cấp và chi phí cấp phép trong khi vẫn cung cấp chức năng tương tự.
+
+## 4. Chức Năng Cốt Lõi
+
+Các tính năng chính của ERPNext bao gồm:
+
+- **Kế toán & Hóa đơn** – Quản lý sổ cái, thuế và báo cáo tài chính.  
+- **Quản lý Hàng tồn kho** – Theo dõi mức tồn kho, kho hàng và mua sắm.  
+- **Nhân sự & Bảng lương** – Hồ sơ nhân viên, chấm công và xử lý lương.  
+- **CRM & Bán hàng** – Theo dõi khách hàng tiềm năng, quy trình bán hàng và hỗ trợ khách hàng.  
+- **Sản xuất** – Danh sách nguyên vật liệu (BOM), lệnh sản xuất và lập kế hoạch sản xuất.  
+- **Website & Thương mại điện tử** – Cửa hàng trực tuyến tích hợp với cổng thanh toán.  
+
+## 5. Ưu và Nhược Điểm
+
+### **Ưu Điểm**
+
+✅ **100% Miễn phí & Mã nguồn mở** – Không có phí cấp phép.  
+✅ **Khả năng tùy chỉnh cao** – Có thể mở rộng qua Frappe apps.  
+✅ **Giao diện hiện đại & Thân thiện với di động** – Giao diện sạch sẽ, đáp ứng.  
+✅ **Tự lưu trữ hoặc Đám mây** – Triển khai tại chỗ hoặc dùng ERPNext.com.  
+
+### **Nhược Điểm**
+
+❌ **Đường cong học tập dốc** – Yêu cầu một số kiến thức kỹ thuật.  
+❌ **Tích hợp bên thứ ba hạn chế** – So với ERP thương mại.  
+❌ **Mở rộng hiệu suất** – Triển khai lớn có thể cần tối ưu hóa.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+
+### **Yêu Cầu Tiên Quyết**
+
+- **Ubuntu 20.04/22.04 LTS** (Khuyến nghị)  
+- **Python 3.10+**  
+- **MariaDB 10.6+**  
+- **Redis** (Cho bộ nhớ đệm)  
+- **Node.js 16+**  
+
+### **Cài Đặt Từng Bước**
+
+1. **Cập Nhật Gói Hệ Thống**  
+
+   ```bash
+   sudo apt update && sudo apt upgrade -y
+   ```
+
+2. **Cài Đặt Phụ Thuộc**  
+
+   ```bash
+   sudo apt install -y python3-dev python3-pip python3-setuptools python3-venv \
+   mariadb-server redis-server git curl
+   ```
+
+3. **Cài Đặt Node.js & Yarn**  
+
+   ```bash
+   curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+   sudo apt install -y nodejs
+   sudo npm install -g yarn
+   ```
+
+4. **Thiết Lập MariaDB**  
+
+   ```bash
+   sudo mysql_secure_installation
+   ```
+
+   Tạo cơ sở dữ liệu cho ERPNext:
+
+   ```sql
+   CREATE DATABASE erpnext;
+   CREATE USER 'erpnextuser'@'localhost' IDENTIFIED BY 'mậtkhẩucủabạn';
+   GRANT ALL PRIVILEGES ON erpnext.* TO 'erpnextuser'@'localhost';
+   FLUSH PRIVILEGES;
+   ```
+
+5. **Cài Đặt Bench (Công Cụ CLI Frappe)**  
+
+   ```bash
+   sudo pip3 install frappe-bench
+   ```
+
+6. **Khởi Tạo ERPNext**  
+
+   ```bash
+   bench init erpnext --frappe-branch version-14
+   cd erpnext
+   bench new-site erpnext.local
+   ```
+
+7. **Cài Đặt Ứng Dụng ERPNext**  
+
+   ```bash
+   bench get-app erpnext https://github.com/frappe/erpnext
+   bench --site erpnext.local install-app erpnext
+   ```
+
+8. **Khởi Động Máy Chủ Phát Triển**  
+
+   ```bash
+   bench start
+   ```
+
+   Truy cập ERPNext tại `http://localhost:8000`.
+
+### **Triển Khai Sản Xuất**
+
+Để thiết lập sản xuất, sử dụng **Nginx + Supervisor** hoặc triển khai qua **Docker** (xem [ERPNext Docker](https://github.com/frappe/frappe_docker)).
+
+---
+**Kết Luận**  
+ERPNext là một ERP mã nguồn mở mạnh mẽ có thể thay thế các giải pháp thương mại đắt đỏ. Mặc dù yêu cầu một số thiết lập kỹ thuật, tính linh hoạt và chi phí cấp phép bằng không khiến nó lý tưởng cho các doanh nghiệp vừa và nhỏ cũng như doanh nghiệp lớn.  
+
+**Sẵn sàng dùng thử?** Truy cập [kho lưu trữ GitHub](https://github.com/frappe/erpnext) để biết thêm chi tiết!
+
+```

--- a/src/content/posts/open-source-crm-idurar-idurar-erp-crm-vi.md
+++ b/src/content/posts/open-source-crm-idurar-idurar-erp-crm-vi.md
@@ -1,0 +1,128 @@
+---
+lang: vi
+title: "Idurar ERP CRM – Giải Pháp Quản Lý Kinh Doanh Mã Nguồn Mở Miễn Phí"
+description: "Khám phá Idurar ERP CRM, nền tảng quản lý kinh doanh mã nguồn mở mạnh mẽ được xây dựng với Node.js và React. Hoàn hảo cho tự lưu trữ."
+published: 2025-08-11
+tags: ['open-source', 'self-host', 'erp', 'crm', 'accounting', 'nodejs', 'react']
+category: Self-hosted
+author: minhpt
+---
+
+# Idurar ERP CRM – Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+- **URL:** [https://github.com/idurar/idurar-erp-crm](https://github.com/idurar/idurar-erp-crm)  
+- **Số sao:** 7268  
+
+## 2. Mô Tả Dự Án
+**Idurar ERP CRM** là một nền tảng quản lý kinh doanh mã nguồn mở miễn phí được thiết kế để hợp lý hóa hoạt động doanh nghiệp. Được xây dựng với **Node.js (backend) và React (frontend)**, nó tích hợp các chức năng **ERP (Hoạch định Nguồn lực Doanh nghiệp), CRM (Quản lý Quan hệ Khách hàng) và kế toán** vào một giải pháp duy nhất.  
+
+Phần mềm tự lưu trữ này lý tưởng cho các doanh nghiệp vừa và nhỏ tìm kiếm giải pháp thay thế cho các hệ thống ERP/CRM độc quyền đắt đỏ. Nó hỗ trợ **lập hóa đơn, quản lý hàng tồn kho, theo dõi dự án và báo cáo tài chính**, khiến nó trở thành công cụ linh hoạt cho tự động hóa kinh doanh.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Idurar ERP CRM phục vụ như một **giải pháp thay thế tiết kiệm chi phí** cho các giải pháp thương mại như:
+- **SAP Business One**  
+- **Oracle NetSuite**  
+- **Microsoft Dynamics 365**  
+- **Odoo (Giải Pháp Thay Thế Mã Nguồn Mở)**  
+- **Zoho CRM & ERP**  
+
+Đối với doanh nghiệp cần **toàn quyền kiểm soát dữ liệu** mà không có phí cấp phép định kỳ, Idurar là lựa chọn hấp dẫn.
+
+## 4. Chức Năng Cốt Lõi
+Các tính năng chính của Idurar ERP CRM bao gồm:
+- **Module CRM:** Quản lý khách hàng tiềm năng, liên hệ và tương tác khách hàng.  
+- **Kế toán & Hóa đơn:** Tạo hóa đơn, theo dõi thanh toán và quản lý chi phí.  
+- **Quản lý Hàng tồn kho:** Theo dõi mức tồn kho, nhà cung cấp và đơn đặt hàng.  
+- **Quản lý Dự án:** Giao nhiệm vụ, theo dõi tiến độ và quản lý thời hạn.  
+- **Báo cáo & Phân tích:** Tạo báo cáo tài chính và hoạt động.  
+- **Hỗ trợ Đa ngôn ngữ & Đa tiền tệ:** Phù hợp cho doanh nghiệp toàn cầu.  
+
+## 5. Ưu và Nhược Điểm
+### **Ưu Điểm**  
+✅ **100% Miễn phí & Mã nguồn mở** – Không có chi phí cấp phép.  
+✅ **Tự lưu trữ** – Toàn quyền kiểm soát dữ liệu và bảo mật.  
+✅ **Công nghệ hiện đại** – Được xây dựng với **Node.js, React và MongoDB**.  
+✅ **Dạng Module & Có thể mở rộng** – Tùy chỉnh tính năng khi cần.  
+
+### **Nhược Điểm**  
+⚠️ **Yêu cầu Kiến thức Kỹ thuật** – Tự lưu trữ có thể cần kỹ năng quản trị máy chủ.  
+⚠️ **Chỉ Hỗ trợ Cộng đồng** – Chưa có hỗ trợ doanh nghiệp chính thức.  
+⚠️ **Tích hợp bên thứ ba hạn chế** – So với giải pháp ERP/CRM thương mại.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+### **Yêu Cầu Tiên Quyết**  
+- **Máy Chủ Linux (Khuyến nghị Ubuntu 22.04)**  
+- **Node.js (v16+)**  
+- **MongoDB (v5+)**  
+- **Git**  
+- **Nginx (cho reverse proxy, tùy chọn)**  
+
+### **Cài Đặt Từng Bước**  
+1. **Clone Kho Lưu Trữ**  
+   ```bash
+   git clone https://github.com/idurar/idurar-erp-crm.git
+   cd idurar-erp-crm
+   ```
+
+2. **Cài Đặt Phụ Thuộc**  
+   ```bash
+   npm install
+   ```
+
+3. **Cấu Hình Biến Môi Trường**  
+   Đổi tên `.env.example` thành `.env` và cập nhật:  
+   ```env
+   MONGO_URI=mongodb://localhost:27017/idurar
+   JWT_SECRET=bí_mật_jwt_bảo_mật_của_bạn
+   PORT=3000
+   ```
+
+4. **Khởi Động Máy Chủ Backend**  
+   ```bash
+   npm run server
+   ```
+
+5. **Chạy Frontend (React App)**  
+   Mở terminal mới và chạy:  
+   ```bash
+   npm run client
+   ```
+
+6. **Truy Cập Ứng Dụng**  
+   Mở `http://localhost:3000` trong trình duyệt.  
+
+### **Tùy Chọn: Triển Khai với Docker**  
+Nếu bạn thích Docker, sử dụng `docker-compose.yml` có sẵn:  
+```bash
+docker-compose up -d
+```
+
+### **Reverse Proxy với Nginx (Khuyến nghị cho Sản Xuất)**  
+Thêm cấu hình này vào `/etc/nginx/sites-available/idurar`:  
+```nginx
+server {
+    listen 80;
+    server_name yourdomain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+Kích hoạt site:  
+```bash
+sudo ln -s /etc/nginx/sites-available/idurar /etc/nginx/sites-enabled
+sudo systemctl restart nginx
+```
+
+### **Kết Luận**  
+Idurar ERP CRM là một **giải pháp thay thế mạnh mẽ, tiết kiệm chi phí** cho các giải pháp ERP/CRM thương mại. Với **tính linh hoạt tự lưu trữ** và **công nghệ hiện đại**, nó lý tưởng cho các doanh nghiệp ưu tiên **kiểm soát dữ liệu và tùy chỉnh**.  
+
+🚀 **Sẵn sàng dùng thử?** Clone kho lưu trữ và làm theo hướng dẫn cài đặt trên!

--- a/src/content/posts/open-source-crm-illacloud-illa-builder-vi.md
+++ b/src/content/posts/open-source-crm-illacloud-illa-builder-vi.md
@@ -1,0 +1,112 @@
+---
+lang: vi
+title: "Illa Builder: Nền Tảng Low-Code Mã Nguồn Mở Cho Ứng Dụng Kinh Doanh"
+description: "Khám phá Illa Builder, nền tảng low-code mã nguồn mở để xây dựng công cụ nội bộ, bảng điều khiển và ứng dụng CRUD. Hỗ trợ PostgreSQL, MySQL, Supabase và nhiều hơn nữa."
+published: 2025-08-10
+tags: ['open-source', 'self-host', 'low-code', 'dashboard', 'postgresql', 'mysql', 'supabase']
+category: 'Self-hosted'
+author: 'minhpt'
+---
+
+# illacloud/illa-builder - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+- **URL:** [https://github.com/illacloud/illa-builder](https://github.com/illacloud/illa-builder)  
+- **Số sao:** 11,988  
+
+Illa Builder là một nền tảng low-code mã nguồn mở cho phép lập trình viên và doanh nghiệp nhanh chóng xây dựng các công cụ nội bộ, bảng điều khiển và ứng dụng CRUD. Với tích hợp cơ sở dữ liệu và API mở rộng, nó phục vụ như một giải pháp thay thế mạnh mẽ cho các nền tảng độc quyền như Retool.
+
+## 2. Mô Tả Dự Án
+Illa Builder được thiết kế để hợp lý hóa việc phát triển ứng dụng kinh doanh với lượng mã hóa tối thiểu. Nó cung cấp giao diện kéo thả, các thành phần dựng sẵn và tích hợp liền mạch với cơ sở dữ liệu (PostgreSQL, MySQL, MongoDB, v.v.) và API (REST, GraphQL, Hugging Face).  
+
+Các điểm nổi bật chính:  
+✔ **Phát triển low-code** – Xây dựng ứng dụng trực quan với ít kịch bản.  
+✔ **Hỗ trợ đa cơ sở dữ liệu** – Kết nối với PostgreSQL, MySQL, Supabase, MSSQL và nhiều hơn nữa.  
+✔ **Tự động hóa quy trình làm việc** – Lên lịch tác vụ hoặc kích hoạt hành động qua webhooks.  
+✔ **Tự lưu trữ & sẵn sàng đám mây** – Triển khai tại chỗ hoặc sử dụng dịch vụ đám mây.  
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+Illa Builder là giải pháp thay thế mạnh mẽ cho:  
+- **Retool** (Nền tảng low-code độc quyền)  
+- **Appsmith** (Giải pháp thay thế Retool mã nguồn mở)  
+- **Budibase** (Trình xây dựng công cụ nội bộ low-code)  
+- **ToolJet** (Nền tảng phát triển ứng dụng mã nguồn mở)  
+
+## 4. Chức Năng Cốt Lõi
+- **Trình Xây Dựng Giao Diện Kéo Thả** – Lắp ráp bảng điều khiển và biểu mẫu với các thành phần dựng sẵn.  
+- **Tích Hợp Cơ Sở Dữ Liệu** – Hỗ trợ PostgreSQL, MySQL, MongoDB, Supabase và nhiều hơn nữa.  
+- **Hỗ Trợ API & Webhook** – Kết nối với REST, GraphQL và dịch vụ bên ngoài.  
+- **Tự Động Hóa & Lập Lịch** – Thiết lập tác vụ định kỳ hoặc kích hoạt dựa trên sự kiện.  
+- **Tự Lưu Trữ** – Triển khai trên cơ sở hạ tầng của riêng bạn để kiểm soát hoàn toàn.  
+
+## 5. Ưu và Nhược Điểm
+### ✅ **Ưu Điểm**  
+✔ **Mã nguồn mở & miễn phí** – Không bị khóa nhà cung cấp.  
+✔ **Tích hợp phong phú** – Hoạt động với các cơ sở dữ liệu và API chính.  
+✔ **Có thể tự lưu trữ** – Lý tưởng cho doanh nghiệp có yêu cầu tuân thủ nghiêm ngặt.  
+✔ **Cộng đồng tích cực** – Hơn 11K sao GitHub và đang phát triển.  
+
+### ❌ **Nhược Điểm**  
+✖ **Đường cong học tập** – Yêu cầu quen thuộc với cơ sở dữ liệu và API.  
+✖ **Tính năng đám mây hạn chế** – Một số tính năng nâng cao có thể yêu cầu tự lưu trữ.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+### **Yêu Cầu Tiên Quyết**  
+- **Máy Chủ Linux (Khuyến nghị Ubuntu 20.04/22.04)**  
+- **Docker & Docker Compose** (Yêu cầu cho triển khai container hóa)  
+- **Node.js (v16+)** (Tùy chọn cho tùy chỉnh)  
+
+### **Bước 1: Cài Đặt Docker & Docker Compose**
+```bash
+sudo apt update && sudo apt install -y docker.io docker-compose
+sudo systemctl enable --now docker
+```
+
+### **Bước 2: Clone Kho Lưu Trữ**
+```bash
+git clone https://github.com/illacloud/illa-builder.git
+cd illa-builder
+```
+
+### **Bước 3: Cấu Hình Biến Môi Trường**
+Chỉnh sửa file `.env`:
+```env
+# Cấu hình cơ sở dữ liệu (khuyến nghị PostgreSQL)
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=illa_user
+DB_PASSWORD=mật_khẩu_bảo_mật_của_bạn
+DB_NAME=illa_db
+```
+
+### **Bước 4: Khởi Động Các Dịch Vụ**
+```bash
+docker-compose up -d
+```
+
+### **Bước 5: Truy Cập Illa Builder**
+Mở trình duyệt và điều hướng đến:  
+`http://địa-chỉ-máy-chủ-của-bạn:3000`  
+
+### **Sau Thiết Lập**
+- Tạo tài khoản quản trị.  
+- Cấu hình kết nối cơ sở dữ liệu trong giao diện.  
+
+### **Tùy Chọn: Reverse Proxy (Nginx)**
+Để sản xuất, thiết lập HTTPS với Nginx:
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+    }
+}
+```
+
+### **Kết Luận**
+Illa Builder là giải pháp thay thế mã nguồn mở mạnh mẽ cho Retool, cung cấp tính linh hoạt, tự lưu trữ và tích hợp mở rộng. Dù bạn cần bảng điều khiển, ứng dụng CRUD hay tự động hóa quy trình làm việc, Illa Builder đơn giản hóa việc phát triển trong khi giữ chi phí thấp.  
+
+🔗 **Bắt Đầu:** [Kho Lưu Trữ GitHub](https://github.com/illacloud/illa-builder) | [Tài Liệu Chính Thức](https://www.illacloud.com/docs)

--- a/src/content/posts/open-source-crm-metasfresh-metasfresh-vi.md
+++ b/src/content/posts/open-source-crm-metasfresh-metasfresh-vi.md
@@ -1,0 +1,164 @@
+---
+lang: vi
+title: "Metasfresh ERP: Đánh Giá Toàn Diện Về Giải Pháp Quản Lý Kinh Doanh Mã Nguồn Mở"
+description: "Khám phá metasfresh, hệ thống ERP mã nguồn mở mạnh mẽ được thiết kế cho khả năng mở rộng kinh doanh. Tìm hiểu về tính năng, cài đặt và cách nó so sánh với các giải pháp thương mại."
+published: 2025-08-21
+tags: ['open-source', 'self-host', 'erp', 'java', 'postgresql', 'business-software', 'docker']
+category: Self-hosted
+author: minhpt
+---
+
+# metasfresh/metasfresh - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/metasfresh/metasfresh](https://github.com/metasfresh/metasfresh)
+- **Số sao:** 1951
+- **Giấy phép:** GPL-3.0
+- **Ngôn ngữ chính:** Java
+- **Cập nhật lần cuối:** Tháng 8, 2025
+
+## 2. Mô Tả Dự Án
+
+Metasfresh là một hệ thống Hoạch định Nguồn lực Doanh nghiệp (ERP) mã nguồn mở hiện đại được xây dựng cho các doanh nghiệp tìm kiếm giải pháp quản lý linh hoạt, có khả năng mở rộng và tiết kiệm chi phí. Không giống các hệ thống ERP nguyên khối truyền thống, metasfresh cung cấp kiến trúc module cho phép tổ chức chỉ triển khai các thành phần cần thiết trong khi vẫn duy trì khả năng mở rộng khi doanh nghiệp phát triển. Dự án nhấn mạnh tính linh hoạt, thân thiện với người dùng và phát triển dựa trên cộng đồng, khiến nó trở thành giải pháp thay thế hấp dẫn cho các giải pháp ERP thương mại đắt đỏ.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+Metasfresh phục vụ như giải pháp thay thế cạnh tranh cho nhiều hệ thống ERP thương mại và mã nguồn mở phổ biến, bao gồm:
+
+- SAP Business One
+- Microsoft Dynamics 365
+- Oracle NetSuite
+- Odoo ERP
+- ERPNext
+- Compiere ERP
+
+## 4. Chức Năng Cốt Lõi
+
+Metasfresh cung cấp khả năng quản lý kinh doanh toàn diện thông qua thiết kế module:
+
+**Các Module Cốt Lõi:**
+- **Kế toán & Tài chính:** Sổ cái tổng hợp, khoản phải thu/phải trả, báo cáo tài chính
+- **Quản lý Hàng tồn kho:** Theo dõi tồn kho thời gian thực, quản lý kho, theo dõi lô hàng
+- **Bán hàng & CRM:** Quản lý khách hàng, xử lý đơn hàng bán, quản lý báo giá
+- **Mua sắm:** Quản lý đơn đặt hàng, quản lý nhà cung cấp, xử lý yêu cầu mua hàng
+- **Sản xuất:** Lập kế hoạch nguồn lực sản xuất, danh sách nguyên vật liệu, lập lịch sản xuất
+- **Báo cáo & Phân tích:** Bảng điều khiển có thể tùy chỉnh, thông minh kinh doanh, xuất dữ liệu
+
+**Tính Năng Nâng Cao:**
+- RESTful API để tích hợp với hệ thống bên thứ ba
+- Giao diện web đáp ứng trên di động
+- Hỗ trợ đa công ty và đa tiền tệ
+- Hệ thống quản lý tài liệu
+- Công cụ tự động hóa quy trình làm việc
+- Công cụ cộng tác thời gian thực
+
+## 5. Ưu và Nhược Điểm
+
+**Ưu Điểm:**
+- ✅ **Tiết kiệm Chi phí:** Hoàn toàn miễn phí và mã nguồn mở, không có phí cấp phép
+- ✅ **Kiến trúc Linh hoạt:** Thiết kế module cho phép triển khai tùy chỉnh
+- ✅ **Cộng đồng Tích cực:** Cập nhật thường xuyên và hỗ trợ cộng đồng
+- ✅ **Có thể Mở rộng:** Xử lý từ doanh nghiệp nhỏ đến hoạt động cấp doanh nghiệp
+- ✅ **Giao diện Hiện đại:** Giao diện dựa trên web trực quan, hỗ trợ di động
+- ✅ **Có thể Mở rộng:** Dễ dàng tích hợp với các hệ thống khác qua API
+
+**Nhược Điểm:**
+- ⚠️ **Đường cong Học tập Dốc:** Yêu cầu chuyên môn kỹ thuật để triển khai và tùy chỉnh
+- ⚠️ **Hỗ trợ Chính thức Hạn chế:** Dựa trên diễn đàn cộng đồng thay vì hỗ trợ chuyên trách
+- ⚠️ **Khoảng trống Tài liệu:** Một số tính năng nâng cao thiếu tài liệu toàn diện
+- ⚠️ **Độ phức tạp Tùy chỉnh:** Các sửa đổi đáng kể yêu cầu kỹ năng phát triển Java
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+
+### Yêu Cầu Tiên Quyết
+- Ubuntu 20.04 LTS trở lên
+- RAM tối thiểu 4GB (khuyến nghị 8GB cho sản xuất)
+- 50GB+ dung lượng lưu trữ
+- Docker và Docker Compose đã cài đặt
+- Tên miền với chứng chỉ SSL (cho sản xuất)
+
+### Cài Đặt Từng Bước
+
+**1. Chuẩn Bị Hệ Thống**
+```bash
+# Cập nhật gói hệ thống
+sudo apt update && sudo apt upgrade -y
+
+# Cài đặt Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# Cài đặt Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+**2. Clone Kho Lưu Trữ Metasfresh**
+```bash
+git clone https://github.com/metasfresh/metasfresh.git
+cd metasfresh/deploy/docker-compose
+```
+
+**3. Cấu Hình Môi Trường**
+```bash
+# Sao chép và chỉnh sửa file môi trường
+cp .env.template .env
+
+# Chỉnh sửa file .env với tùy chọn của bạn
+nano .env
+```
+Sửa đổi các biến chính bao gồm:
+- `DB_PASSWORD`: Đặt mật khẩu cơ sở dữ liệu bảo mật
+- `APP_HOST`: IP hoặc tên miền máy chủ của bạn
+- `AD_ORG_ID`: ID tổ chức của bạn
+
+**4. Khởi Động Dịch Vụ Metasfresh**
+```bash
+# Khởi động tất cả dịch vụ
+docker-compose up -d
+
+# Giám sát quá trình khởi động
+docker-compose logs -f
+```
+
+**5. Thiết Lập Ban Đầu**
+1. Truy cập giao diện web tại `http://địa-chỉ-máy-chủ-của-bạn:3000`
+2. Làm theo trình hướng dẫn thiết lập ban đầu
+3. Tạo tài khoản quản trị
+4. Cấu hình cài đặt tổ chức cơ bản
+5. Nhập dữ liệu ban đầu nếu cần
+
+**6. Triển Khai Sản Xuất (Tùy Chọn)**
+```bash
+# Thiết lập reverse proxy với Nginx
+sudo apt install nginx -y
+
+# Cấu hình SSL với Let's Encrypt
+sudo apt install certbot python3-certbot-nginx -y
+sudo certbot --nginx -d your-domain.com
+```
+
+### Lệnh Bảo Trì
+```bash
+# Kiểm tra trạng thái dịch vụ
+docker-compose ps
+
+# Xem nhật ký
+docker-compose logs
+
+# Cập nhật lên phiên bản mới nhất
+git pull origin master
+docker-compose down
+docker-compose up -d --build
+
+# Sao lưu cơ sở dữ liệu
+docker-compose exec db pg_dump -U metasfresh > backup.sql
+```
+
+### Khắc Phục Sự Cố
+- Đảm bảo cổng 3000 (web), 5432 (cơ sở dữ liệu) và 61616 (message broker) được mở
+- Kiểm tra phân bổ tài nguyên Docker nếu gặp vấn đề hiệu suất
+- Xác minh kết nối cơ sở dữ liệu nếu dịch vụ không khởi động
+
+Metasfresh cung cấp giải pháp ERP mạnh mẽ, sẵn sàng cho doanh nghiệp, kết hợp công nghệ hiện đại với tính linh hoạt của mã nguồn mở. Mặc dù thiết lập ban đầu yêu cầu chuyên môn kỹ thuật, lợi ích lâu dài về tiết kiệm chi phí và khả năng tùy chỉnh khiến nó trở thành lựa chọn tuyệt vời cho các doanh nghiệp muốn rời xa các hệ thống ERP độc quyền.

--- a/src/content/posts/open-source-crm-nocobase-nocobase-vi.md
+++ b/src/content/posts/open-source-crm-nocobase-nocobase-vi.md
@@ -1,0 +1,156 @@
+---
+lang: vi
+title: "Đánh Giá NocoBase: Nền Tảng No-Code/Low-Code Mã Nguồn Mở Cho Ứng Dụng Kinh Doanh"
+description: "Khám phá NocoBase, nền tảng no-code/low-code mã nguồn mở để xây dựng ứng dụng kinh doanh. Tìm hiểu về tính năng, ưu & nhược điểm và cách tự lưu trữ."
+published: 2025-08-29
+tags: ['open-source', 'self-host', 'nocobase', 'no-code', 'low-code', 'business-apps']
+category: Self-hosted
+author: minhpt
+---
+
+# nocobase/nocobase - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+
+- **URL:** [https://github.com/nocobase/nocobase](https://github.com/nocobase/nocobase)  
+- **Số sao:** 15,466 (tính đến tháng 11/2023)  
+
+NocoBase là một dự án mã nguồn mở đang phát triển nhanh chóng, cho phép doanh nghiệp và lập trình viên xây dựng các ứng dụng mạnh mẽ mà không cần kiến thức mã hóa sâu rộng. Với hơn 15K sao trên GitHub, nó đã đạt được sự phát triển đáng kể trong lĩnh vực no-code/low-code.
+
+## 2. Mô Tả Dự Án
+
+NocoBase là một **nền tảng no-code/low-code mã nguồn mở ưu tiên khả năng mở rộng** được thiết kế để tạo ứng dụng kinh doanh và giải pháp doanh nghiệp. Nó cho phép người dùng:  
+✔ Xây dựng ứng dụng tùy chỉnh với mã hóa tối thiểu  
+✔ Tự động hóa quy trình làm việc và quy trình kinh doanh  
+✔ Quản lý dữ liệu với cấu trúc cơ sở dữ liệu linh hoạt  
+✔ Triển khai giải pháp tự lưu trữ để kiểm soát hoàn toàn  
+
+Không giống nhiều công cụ no-code độc quyền, NocoBase là **mã nguồn mở**, nghĩa là bạn có thể sửa đổi và mở rộng nó một cách tự do mà không bị khóa nhà cung cấp.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+
+NocoBase cạnh tranh với nhiều giải pháp thương mại và mã nguồn mở, bao gồm:  
+
+- **Airtable** (cho cơ sở dữ liệu và tự động hóa)  
+- **Retool** (cho xây dựng công cụ nội bộ)  
+- **Appsmith** (giải pháp thay thế mã nguồn mở cho ứng dụng kinh doanh)  
+- **OutSystems/Mendix** (nền tảng low-code doanh nghiệp)  
+
+Không giống các công cụ này, NocoBase **hoàn toàn có thể tự lưu trữ** và **có thể mở rộng** mà không có phí cấp phép.
+
+## 4. Chức Năng Cốt Lõi
+
+### Tính Năng Chính
+
+- **Trình Xây Dựng No-Code/Low-Code** – Giao diện kéo thả để tạo biểu mẫu, bảng và bảng điều khiển.  
+- **Plugin Có Thể Mở Rộng** – Thêm chức năng tùy chỉnh qua plugin (REST APIs, tự động hóa, v.v.).  
+- **Kiểm Soát Truy Cập Dựa Trên Vai Trò** – Phân quyền chi tiết cho nhóm.  
+- **Quản Lý Cơ Sở Dữ Liệu** – Hỗ trợ PostgreSQL và SQLite với tùy chỉnh lược đồ.  
+- **Tự Động Hóa Quy Trình Làm Việc** – Xác định logic kinh doanh mà không cần mã hóa.  
+- **Triển Khai Tự Lưu Trữ** – Kiểm soát hoàn toàn dữ liệu và cơ sở hạ tầng.  
+
+## 5. Ưu và Nhược Điểm
+
+### ✅ **Ưu Điểm**  
+
+✔ **Mã nguồn mở & miễn phí** – Không bị khóa nhà cung cấp hoặc phí đăng ký.  
+✔ **Khả năng mở rộng cao** – Lập trình viên có thể thêm plugin tùy chỉnh.  
+✔ **Có thể tự lưu trữ** – Lý tưởng cho doanh nghiệp quan tâm đến quyền riêng tư.  
+✔ **Cộng đồng tích cực** – Sự hiện diện GitHub đang phát triển với cập nhật thường xuyên.  
+
+### ❌ **Nhược Điểm**  
+
+✖ **Đường cong học tập dốc hơn** so với một số công cụ no-code thương mại.  
+✖ **Tích hợp bên thứ ba hạn chế** so với Airtable hoặc Retool.  
+✖ **Yêu cầu kiến thức kỹ thuật** để tự lưu trữ.  
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ trên Ubuntu)
+
+NocoBase có thể được triển khai bằng **Docker** để thiết lập dễ dàng.  
+
+### **Yêu Cầu Tiên Quyết:**  
+
+- Ubuntu 20.04/22.04 (hoặc bất kỳ bản phân phối Linux nào có Docker)  
+- Docker & Docker Compose đã cài đặt  
+- RAM 2GB+ (khuyến nghị 4GB cho sản xuất)  
+
+### **Thiết Lập Từng Bước:**  
+
+#### **1. Cài Đặt Docker & Docker Compose**  
+
+```bash
+# Cài đặt Docker
+sudo apt update && sudo apt install -y docker.io
+sudo systemctl enable --now docker
+
+# Cài đặt Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+#### **2. Clone Kho Lưu Trữ NocoBase**  
+
+```bash
+git clone https://github.com/nocobase/nocobase.git
+cd nocobase
+```
+
+#### **3. Cấu Hình Môi Trường**  
+
+Tạo file `.env`:  
+
+```bash
+cp .env.example .env
+```
+
+Chỉnh sửa `.env` để đặt:  
+
+```
+DB_DIALECT=postgres
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=nocobase
+DB_USER=nocobase
+DB_PASSWORD=mật_khẩu_bảo_mật_của_bạn
+```
+
+#### **4. Khởi Động NocoBase với Docker Compose**  
+
+```bash
+docker-compose up -d
+```
+
+#### **5. Truy Cập Ứng Dụng**  
+
+Sau khi chạy, mở `http://địa-chỉ-máy-chủ-của-bạn:13000` trong trình duyệt.  
+
+#### **6. (Tùy Chọn) Thiết Lập Nginx Reverse Proxy**  
+
+Để sản xuất, sử dụng Nginx để kích hoạt HTTPS:  
+
+```nginx
+server {
+    listen 80;
+    server_name yourdomain.com;
+
+    location / {
+        proxy_pass http://localhost:13000;
+        proxy_set_header Host $host;
+    }
+}
+```
+
+Sau đó, bảo mật với Let's Encrypt:  
+
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d yourdomain.com
+```
+
+### **Kết Luận**  
+
+NocoBase là giải pháp thay thế mã nguồn mở mạnh mẽ cho các nền tảng no-code thương mại, cung cấp tính linh hoạt và kiểm soát cho doanh nghiệp. Mặc dù yêu cầu một số thiết lập kỹ thuật, khả năng mở rộng của nó khiến nó trở nên lý tưởng cho các giải pháp tùy chỉnh.  
+
+🔗 **Bắt Đầu:** [NocoBase GitHub](https://github.com/nocobase/nocobase)
+
+```

--- a/src/content/posts/open-source-crm-openblocks-dev-openblocks-vi.md
+++ b/src/content/posts/open-source-crm-openblocks-dev-openblocks-vi.md
@@ -1,0 +1,128 @@
+---
+lang: vi
+title: "OpenBlocks: Giải Pháp Thay Thế Retool Mã Nguồn Mở Để Xây Dựng Công Cụ Nội Bộ"
+description: "Khám phá OpenBlocks, giải pháp thay thế Retool mã nguồn mở mạnh mẽ để tạo công cụ nội bộ dễ dàng. Tìm hiểu tính năng, ưu nhược điểm và cách tự lưu trữ."
+published: 2025-08-12
+tags: ['open-source', 'self-host', 'low-code', 'internal-tools', 'docker', 'javascript']
+category: 'Self-hosted'
+author: minhpt
+---
+
+# openblocks-dev/openblocks - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+- **URL:** [https://github.com/openblocks-dev/openblocks](https://github.com/openblocks-dev/openblocks)
+- **Số sao:** 6015 (tính đến tháng 8/2025)
+- **Giấy phép:** AGPL-3.0
+- **Ngôn ngữ chính:** JavaScript/TypeScript
+
+## 2. Mô Tả Dự Án
+OpenBlocks là một nền tảng low-code mã nguồn mở được thiết kế để giúp lập trình viên và doanh nghiệp nhanh chóng xây dựng các công cụ nội bộ, bảng điều khiển và bảng quản trị. Nó cung cấp trình xây dựng giao diện kéo thả với các thành phần dựng sẵn, bộ kết nối cơ sở dữ liệu và tích hợp API, cho phép nhóm tạo ứng dụng tùy chỉnh mà không cần mã hóa phức tạp.
+
+Được định vị như giải pháp thay thế Retool, OpenBlocks nhấn mạnh vào tự lưu trữ, tùy chỉnh và quy trình làm việc thân thiện với lập trình viên trong khi vẫn duy trì khả năng cấp doanh nghiệp.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+OpenBlocks cạnh tranh với nhiều giải pháp thương mại và mã nguồn mở:
+- **Retool** (Giải pháp thay thế chính)
+- **Appsmith** (Đối thủ mã nguồn mở)
+- **Budibase** (Nền tảng low-code)
+- **Internal.io** (Trình xây dựng công cụ nội bộ SaaS)
+- Bảng quản trị tự xây dựng (Tiết kiệm thời gian phát triển)
+
+## 4. Chức Năng Cốt Lõi
+### Tính Năng Chính:
+- **Trình Xây Dựng Giao Diện Kéo Thả**  
+  Các thành phần dựng sẵn (bảng, biểu mẫu, biểu đồ) với bố cục có thể tùy chỉnh.
+- **Tích Hợp Cơ Sở Dữ Liệu & API**  
+  Hỗ trợ PostgreSQL, MySQL, MongoDB, REST APIs, GraphQL và nhiều hơn nữa.
+- **Truy Vấn JavaScript**  
+  Viết logic tùy chỉnh với đoạn mã JavaScript.
+- **Kiểm Soát Truy Cập Dựa Trên Vai Trò (RBAC)**  
+  Phân quyền chi tiết cho nhóm.
+- **Có Thể Tự Lưu Trữ**  
+  Kiểm soát hoàn toàn triển khai và dữ liệu.
+- **Hỗ Trợ Đa Môi Trường**  
+  Phân tách Dev/Test/Prod với biến môi trường.
+
+### Trường Hợp Sử Dụng:
+- Bảng điều khiển quản trị
+- Giao diện CRM/ERP
+- Công cụ trực quan hóa dữ liệu
+- Tự động hóa quy trình làm việc nội bộ
+
+## 5. Ưu và Nhược Điểm
+### ✅ **Ưu Điểm**
+- **Tiết kiệm Chi phí:** Miễn phí và mã nguồn mở (giấy phép AGPL).
+- **Có thể Tự lưu trữ:** Không bị khóa nhà cung cấp; dữ liệu ở lại trên cơ sở hạ tầng của bạn.
+- **Có thể Mở rộng:** Hỗ trợ JavaScript tùy chỉnh và plugin.
+- **Cộng đồng Tích cực:** Sự hiện diện GitHub đang phát triển với cập nhật thường xuyên.
+- **Trải nghiệm Giống Retool:** Giao diện quen thuộc cho người dùng Retool.
+
+### ❌ **Nhược Điểm**
+- **Đường cong Học tập:** Yêu cầu kiến thức JavaScript/SQL cơ bản cho quy trình làm việc phức tạp.
+- **Hệ sinh thái Trẻ hơn:** Ít mẫu dựng sẵn hơn Retool.
+- **Giấy phép AGPL:** Có thể không phù hợp với mọi trường hợp sử dụng thương mại (tham khảo ý kiến pháp lý).
+
+## 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ trên Ubuntu)
+### Yêu Cầu Tiên Quyết:
+- Ubuntu 22.04 LTS (hoặc mới hơn)
+- Docker & Docker Compose
+- RAM 4GB+ (khuyến nghị 8GB cho sản xuất)
+- Tên miền/SSL (cho HTTPS)
+
+### Thiết Lập Từng Bước:
+1. **Cài Đặt Docker**  
+   ```bash
+   sudo apt update && sudo apt install -y docker.io docker-compose
+   sudo systemctl enable docker
+   ```
+
+2. **Clone OpenBlocks**  
+   ```bash
+   git clone https://github.com/openblocks-dev/openblocks.git
+   cd openblocks
+   ```
+
+3. **Cấu Hình Môi Trường**  
+   Chỉnh sửa file `.env`:
+   ```env
+   # Cơ sở dữ liệu
+   MONGODB_URI=mongodb://mongo:27017/openblocks
+   POSTGRES_HOST=postgres
+   POSTGRES_USER=openblocks
+   POSTGRES_PASSWORD=mật_khẩu_bảo_mật_của_bạn
+   POSTGRES_DB=openblocks
+
+   # Cài đặt ứng dụng
+   ENCRYPTION_PASSWORD=khóa_mã_hóa_của_bạn
+   SUPERUSER_PASSWORD=admin123  # Đổi cái này!
+   ```
+
+4. **Khởi Động Containers**  
+   ```bash
+   docker-compose up -d
+   ```
+
+5. **Truy Cập OpenBlocks**  
+   Truy cập `http://địa-chỉ-máy-chủ-của-bạn:3000`  
+   Đăng nhập với:  
+   - Email: `admin@openblocks.dev`  
+   - Mật khẩu: `admin123` (đổi sau khi đăng nhập!)
+
+### Sau Khi Cài Đặt:
+- **Thiết lập HTTPS** (Sử dụng reverse proxy Nginx/Caddy)
+- **Sao lưu** dữ liệu MongoDB/Postgres thường xuyên
+- **Giám sát** với `docker-compose logs -f`
+
+### Cập Nhật:
+```bash
+git pull origin main
+docker-compose down && docker-compose up -d --build
+```
+
+---
+
+**Kết Luận:**  
+OpenBlocks là lựa chọn tuyệt vời cho các nhóm muốn có chức năng giống Retool mà không bị khóa nhà cung cấp. Mặc dù có thể thiếu một số trau chuốt so với các giải pháp thương mại, bản chất mã nguồn mở và sự phát triển tích cực khiến nó trở thành lựa chọn hấp dẫn cho công cụ nội bộ tự lưu trữ.
+
+Sẵn sàng dùng thử? Clone kho lưu trữ và triển khai ứng dụng đầu tiên của bạn ngay hôm nay! 🚀

--- a/src/content/posts/open-source-crm-salesagility-SuiteCRM-vi.md
+++ b/src/content/posts/open-source-crm-salesagility-SuiteCRM-vi.md
@@ -1,0 +1,96 @@
+---
+lang: vi
+title: "Đánh Giá SuiteCRM: Giải Pháp Thay Thế Salesforce Mã Nguồn Mở"
+description: "Khám phá SuiteCRM, giải pháp CRM mã nguồn mở mạnh mẽ có thể cạnh tranh với các nền tảng thương mại như Salesforce. Tìm hiểu về tính năng, ưu & nhược điểm và cách tự lưu trữ."
+published: 2025-08-14
+tags: ['open-source', 'self-host', 'crm', 'php', 'mysql', 'sales-automation']
+category: Self-hosted
+author: minhpt
+---
+
+# salesagility/SuiteCRM - Đánh Giá Chi Tiết
+
+## 1. Tổng Quan & Thống Kê GitHub
+- **URL:** [https://github.com/salesagility/SuiteCRM](https://github.com/salesagility/SuiteCRM)  
+- **Số sao:** 4830  
+- **Giấy phép:** GNU Affero General Public License v3.0  
+- **Ngôn ngữ chính:** PHP  
+
+## 2. Mô Tả Dự Án
+SuiteCRM là một **nền tảng Quản lý Quan hệ Khách hàng (CRM) hoàn toàn mã nguồn mở** cung cấp các tính năng cấp doanh nghiệp mà không có chi phí cấp phép của các giải pháp thương mại. Được fork từ SugarCRM vào năm 2013, nó đã phát triển thành một giải pháp thay thế mạnh mẽ với **tự động hóa bán hàng, công cụ tiếp thị, hỗ trợ khách hàng và khả năng báo cáo**.
+
+Không giống nhiều CRM tính phí theo người dùng, SuiteCRM **miễn phí sử dụng, sửa đổi và triển khai**, khiến nó lý tưởng cho doanh nghiệp ở mọi quy mô. Nó hỗ trợ **module tùy chỉnh, quy trình làm việc và tích hợp** trong khi duy trì giao diện thân thiện với người dùng.
+
+## 3. Phần Mềm Này Thay Thế Những Gì?
+SuiteCRM cạnh tranh với:
+- **Salesforce** (Thương mại)  
+- **HubSpot CRM** (Freemium)  
+- **Zoho CRM** (Freemium)  
+- **SugarCRM Professional** (Trả phí)  
+- **Microsoft Dynamics 365** (Thương mại)  
+
+## 4. Chức Năng Cốt Lõi
+Các tính năng chính bao gồm:
+- **Tự động hóa Bán hàng**: Quản lý khách hàng tiềm năng, cơ hội và quy trình bán hàng.  
+- **Công cụ Tiếp thị**: Chiến dịch email, biểu mẫu thu thập khách hàng tiềm năng và phân tích.  
+- **Hỗ trợ Khách hàng**: Theo dõi trường hợp và hệ thống vé.  
+- **Báo cáo & Bảng Điều khiển**: Báo cáo có thể tùy chỉnh và phân tích thời gian thực.  
+- **Ứng dụng Di động**: Hỗ trợ iOS và Android.  
+- **API & Tích hợp**: REST API cho công cụ bên thứ ba như Zapier, Mailchimp và QuickBooks.  
+
+## 5. Ưu và Nhược Điểm
+### **Ưu Điểm**  
+✅ **100% Miễn phí & Mã nguồn mở** – Không có phí cấp phép.  
+✅ **Khả năng Tùy chỉnh Cao** – Thêm module hoặc tinh chỉnh quy trình làm việc.  
+✅ **Tự lưu trữ** – Kiểm soát hoàn toàn quyền riêng tư dữ liệu.  
+✅ **Cộng đồng Tích cực** – Cập nhật thường xuyên và plugin.  
+
+### **Nhược Điểm**  
+❌ **Đường cong Học tập Dốc** – Yêu cầu kiến thức kỹ thuật để thiết lập.  
+❌ **Lưu trữ Đám mây Hạn chế** – Chủ yếu được thiết kế để tự lưu trữ.  
+❌ **Không có Hỗ trợ Chính thức** – Dựa trên diễn đàn cộng đồng.  
+
+# 6. Hướng Dẫn Cài Đặt Chi Tiết (Tự Lưu Trữ)
+### **Yêu Cầu Tiên Quyết**  
+- **Máy Chủ Linux** (Khuyến nghị Ubuntu 22.04)  
+- **LAMP Stack**: Apache, MySQL, PHP 7.4+  
+- **Composer** (Trình Quản Lý Phụ Thuộc)  
+
+### **Thiết Lập Từng Bước**  
+1. **Cài Đặt Phụ Thuộc**  
+   ```bash
+   sudo apt update && sudo apt install apache2 mysql-server php libapache2-mod-php php-mysql php-curl php-gd php-mbstring php-xml php-zip
+   ```
+
+2. **Cấu Hình MySQL**  
+   ```bash
+   sudo mysql_secure_installation
+   mysql -u root -p
+   CREATE DATABASE suitecrm;
+   CREATE USER 'suiteuser'@'localhost' IDENTIFIED BY 'YourPassword123';
+   GRANT ALL PRIVILEGES ON suitecrm.* TO 'suiteuser'@'localhost';
+   FLUSH PRIVILEGES;
+   ```
+
+3. **Tải SuiteCRM**  
+   ```bash
+   cd /var/www/html
+   sudo git clone https://github.com/salesagility/SuiteCRM.git
+   sudo chown -R www-data:www-data SuiteCRM
+   ```
+
+4. **Chạy Trình Cài Đặt**  
+   - Truy cập `http://địa-chỉ-máy-chủ-của-bạn/SuiteCRM` trong trình duyệt.  
+   - Làm theo trình hướng dẫn thiết lập (chi tiết cơ sở dữ liệu: `suitecrm`, `suiteuser`, `YourPassword123`).  
+
+5. **Cron Jobs (Tùy Chọn cho Tự động hóa)**  
+   ```bash
+   sudo crontab -u www-data -e
+   */5 * * * * php /var/www/html/SuiteCRM/cron.php > /dev/null 2>&1
+   ```
+
+### **Sau Khi Cài Đặt**  
+- Bảo mật với HTTPS bằng Let's Encrypt.  
+- Sao lưu `/var/www/html/SuiteCRM` và cơ sở dữ liệu MySQL thường xuyên.  
+
+**Xong!** Bạn đã có một **CRM tự lưu trữ** cạnh tranh được với Salesforce. 🚀  

--- a/src/content/posts/open-source-self-hosted-with-docker-vi.md
+++ b/src/content/posts/open-source-self-hosted-with-docker-vi.md
@@ -1,0 +1,172 @@
+---
+lang: vi
+title: >- 
+  SaaS Mã Nguồn Mở: Tự Lưu Trữ với Docker (Phần 1)
+description: >-
+  Khám phá các giải pháp thay thế SaaS mã nguồn mở tốt nhất mà bạn có thể tự lưu trữ với Docker. Tiết kiệm tiền, bảo vệ dữ liệu và kiểm soát công cụ của bạn.
+author: minhpt
+published: 2025-03-25
+category: Self-hosted
+tags: [self-hosted, open-source, docker, saas]
+---
+
+Trong thời đại kỹ thuật số ngày nay, các giải pháp Software-as-a-Service (SaaS) thống trị thị trường. Tuy nhiên, nhiều dịch vụ này đi kèm với chi phí định kỳ, lo ngại về quyền riêng tư và khả năng tùy chỉnh hạn chế. Điều gì sẽ xảy ra nếu bạn có thể thay thế các công cụ SaaS này bằng các giải pháp thay thế mã nguồn mở mà bạn có thể tự lưu trữ bằng Docker? Bạn không chỉ tiết kiệm tiền mà còn có toàn quyền kiểm soát dữ liệu và cơ sở hạ tầng của mình.
+
+Trong bài viết này, chúng ta sẽ khám phá một số giải pháp thay thế SaaS mã nguồn mở tốt nhất mà bạn có thể tự lưu trữ bằng Docker. Mỗi công cụ đi kèm với mô tả ngắn gọn, tóm tắt chức năng, trường hợp sử dụng, kho lưu trữ GitHub và lệnh Docker để bắt đầu.
+
+### 1. **Nextcloud**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/nextcloud-hub-files-25-preview.png)
+
+**Mô tả**: Nextcloud là nền tảng năng suất tự lưu trữ thay thế các công cụ như Google Drive, Dropbox và Microsoft 365.  
+**Tóm tắt Chức năng**: Lưu trữ file, lịch, danh bạ, quản lý tác vụ và chỉnh sửa cộng tác.  
+**Trường hợp Sử dụng**: Hoàn hảo cho nhóm hoặc cá nhân tìm kiếm giải pháp đám mây riêng tư.  
+**Kho lưu trữ GitHub**: [https://github.com/nextcloud/server](https://github.com/nextcloud/server)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name nextcloud \
+  -p 8080:80 \
+  -v nextcloud:/var/www/html \
+  nextcloud
+```
+
+---
+
+### 2. **Matomo**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/matomo.webp)
+
+**Mô tả**: Matomo là nền tảng phân tích mã nguồn mở thay thế Google Analytics.  
+**Tóm tắt Chức năng**: Theo dõi lưu lượng truy cập website, hành vi người dùng và tạo báo cáo chi tiết.  
+**Trường hợp Sử dụng**: Lý tưởng cho doanh nghiệp muốn sở hữu dữ liệu phân tích và tuân thủ quy định về quyền riêng tư như GDPR.  
+**Kho lưu trữ GitHub**: [https://github.com/matomo-org/matomo](https://github.com/matomo-org/matomo)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name matomo \
+  -p 8081:80 \
+  -v matomo_data:/var/www/html \
+  matomo
+```
+
+---
+
+### 3. **Rocket.Chat**
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/rocket-chat.webp)
+
+**Mô tả**: Rocket.Chat là nền tảng giao tiếp nhóm tự lưu trữ thay thế Slack hoặc Microsoft Teams.  
+**Tóm tắt Chức năng**: Nhắn tin thời gian thực, gọi video, chia sẻ file và tích hợp với các công cụ khác.  
+**Trường hợp Sử dụng**: Tuyệt vời cho nhóm cần nền tảng giao tiếp an toàn và có thể tùy chỉnh.  
+**Kho lưu trữ GitHub**: [https://github.com/RocketChat/Rocket.Chat](https://github.com/RocketChat/Rocket.Chat)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name rocketchat \
+  -p 3000:3000 \
+  -v rocketchat_data:/app/uploads \
+  rocket.chat
+```
+
+---
+
+### 4. **InvoiceNinja**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/invoice-ninja.png)
+
+**Mô tả**: InvoiceNinja là nền tảng lập hóa đơn và thanh toán mã nguồn mở thay thế các công cụ như FreshBooks hoặc QuickBooks.  
+**Tóm tắt Chức năng**: Tạo hóa đơn, theo dõi chi phí, quản lý khách hàng và chấp nhận thanh toán.  
+**Trường hợp Sử dụng**: Hoàn hảo cho freelancer và doanh nghiệp nhỏ tìm kiếm giải pháp lập hóa đơn tự lưu trữ.  
+**Kho lưu trữ GitHub**: [https://github.com/invoiceninja/invoiceninja](https://github.com/invoiceninja/invoiceninja)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name invoiceninja \
+  -p 8082:80 \
+  -v invoiceninja_data:/var/www/app/storage \
+  invoiceninja/invoiceninja
+```
+
+---
+
+### 5. **Bitwarden**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/bitwarden.png)
+
+**Mô tả**: Bitwarden là trình quản lý mật khẩu mã nguồn mở thay thế LastPass hoặc 1Password.  
+**Tóm tắt Chức năng**: Lưu trữ và quản lý mật khẩu an toàn, tạo mật khẩu mạnh và chia sẻ thông tin đăng nhập với nhóm.  
+**Trường hợp Sử dụng**: Cần thiết cho cá nhân và nhóm ưu tiên bảo mật mật khẩu.  
+**Kho lưu trữ GitHub**: [https://github.com/bitwarden/server](https://github.com/bitwarden/server)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name bitwarden \
+  -p 8083:80 \
+  -v bitwarden_data:/data \
+  bitwardenrs/server
+```
+
+---
+
+### 6. **Gitea**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/gitea.png)
+
+**Mô tả**: Gitea là dịch vụ Git tự lưu trữ thay thế GitHub hoặc GitLab.  
+**Tóm tắt Chức năng**: Lưu trữ và quản lý kho lưu trữ Git, theo dõi vấn đề và cộng tác.  
+**Trường hợp Sử dụng**: Lý tưởng cho lập trình viên và nhóm muốn giải pháp Git nhẹ và riêng tư.  
+**Kho lưu trữ GitHub**: [https://github.com/go-gitea/gitea](https://github.com/go-gitea/gitea)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name gitea \
+  -p 3001:3000 \
+  -v gitea_data:/data \
+  gitea/gitea
+```
+
+---
+
+### 7. **Strapi**  
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/strapi.svg){: width="318" }
+
+**Mô tả**: Strapi là CMS headless mã nguồn mở thay thế WordPress hoặc Contentful.  
+**Tóm tắt Chức năng**: Xây dựng và quản lý API cho các ứng dụng giàu nội dung.  
+**Trường hợp Sử dụng**: Hoàn hảo cho lập trình viên xây dựng website hoặc ứng dụng hiện đại với backend nội dung linh hoạt.  
+**Kho lưu trữ GitHub**: [https://github.com/strapi/strapi](https://github.com/strapi/strapi)  
+**Lệnh Docker**:  
+
+```bash
+docker run -d \
+  --name strapi \
+  -p 1337:1337 \
+  -v strapi_data:/srv/app \
+  strapi/strapi
+```
+
+---
+
+### Tại Sao Nên Tự Lưu Trữ với Docker?  
+
+Tự lưu trữ với Docker mang lại nhiều lợi ích:  
+
+- **Tiết Kiệm Chi Phí**: Không có phí đăng ký SaaS định kỳ.  
+- **Quyền Sở Hữu Dữ Liệu**: Dữ liệu của bạn ở lại trên máy chủ của bạn, đảm bảo quyền riêng tư và tuân thủ.  
+- **Tùy Chỉnh**: Điều chỉnh phần mềm theo nhu cầu cụ thể của bạn.  
+- **Tính Di Động**: Container Docker dễ dàng triển khai và di chuyển qua các môi trường.  
+
+---
+
+### Kết Luận  
+
+Bằng cách tự lưu trữ các giải pháp thay thế SaaS mã nguồn mở này, bạn có thể kiểm soát các công cụ kỹ thuật số của mình trong khi tiết kiệm tiền và tăng cường quyền riêng tư. Docker làm cho quy trình trở nên liền mạch, cho phép bạn triển khai và quản lý các ứng dụng này một cách dễ dàng. Dù bạn là lập trình viên, blogger hay chủ doanh nghiệp, những công cụ này có thể giúp bạn thoát khỏi các ràng buộc của SaaS độc quyền.  
+
+Hãy bắt đầu tự lưu trữ ngay hôm nay và khám phá tiềm năng thực sự của phần mềm mã nguồn mở!  

--- a/src/content/posts/text-and-typo-vi.md
+++ b/src/content/posts/text-and-typo-vi.md
@@ -1,0 +1,198 @@
+---
+lang: vi
+title: Văn Bản và Kiểu Chữ trong Jekyll
+description: Ví dụ về văn bản, kiểu chữ, phương trình toán học, sơ đồ, flowchart, hình ảnh, video và nhiều hơn nữa.
+author: minhpt
+published: 2025-03-25
+category: Self-hosted
+tags: [typography, jekyll, blog, github, self-hosted, tutorial]
+math: true
+mermaid: true
+image: https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/devices-mockup.png
+---
+
+## Tiêu đề
+
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable -->
+# H1 — tiêu đề
+{: .mt-4 .mb-0 }
+
+## H2 — tiêu đề
+{: data-toc-skip='' .mt-4 .mb-0 }
+
+### H3 — tiêu đề
+{: data-toc-skip='' .mt-4 .mb-0 }
+
+#### H4 — tiêu đề
+{: data-toc-skip='' .mt-4 }
+<!-- markdownlint-restore -->
+
+## Đoạn văn
+
+Quisque egestas convallis ipsum, ut sollicitudin risus tincidunt a. Maecenas interdum malesuada egestas. Duis consectetur porta risus, sit amet vulputate urna facilisis ac. Phasellus semper dui non purus ultrices sodales. Aliquam ante lorem, ornare a feugiat ac, finibus nec mauris. Vivamus ut tristique nisi. Sed vel leo vulputate, efficitur risus non, posuere mi. Nullam tincidunt bibendum rutrum. Proin commodo ornare sapien. Vivamus interdum diam sed sapien blandit, sit amet aliquam risus mattis. Nullam arcu turpis, mollis quis laoreet at, placerat id nibh. Suspendisse venenatis eros eros.
+
+## Danh sách
+
+### Danh sách có thứ tự
+
+1. Thứ nhất
+2. Thứ hai
+3. Thứ ba
+
+### Danh sách không thứ tự
+
+- Chương
+  - Phần
+    - Đoạn
+
+### Danh sách việc cần làm
+
+- [ ] Công việc
+  - [x] Bước 1
+  - [x] Bước 2
+  - [ ] Bước 3
+
+### Danh sách mô tả
+
+Mặt trời
+: ngôi sao mà trái đất quay quanh
+
+Mặt trăng
+: vệ tinh tự nhiên của trái đất, có thể nhìn thấy nhờ ánh sáng phản chiếu từ mặt trời
+
+## Trích dẫn khối
+
+> Dòng này thể hiện _trích dẫn khối_.
+
+## Lời nhắc
+
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable -->
+> Ví dụ về lời nhắc loại `tip`.
+{: .prompt-tip }
+
+> Ví dụ về lời nhắc loại `info`.
+{: .prompt-info }
+
+> Ví dụ về lời nhắc loại `warning`.
+{: .prompt-warning }
+
+> Ví dụ về lời nhắc loại `danger`.
+{: .prompt-danger }
+<!-- markdownlint-restore -->
+
+## Bảng
+
+| Công ty                        | Liên hệ          | Quốc gia |
+| :----------------------------- | :--------------- | -------: |
+| Alfreds Futterkiste            | Maria Anders     | Đức     |
+| Island Trading                 | Helen Bennett    | Anh      |
+| Magazzini Alimentari Riuniti   | Giovanni Rovelli | Ý       |
+
+## Liên kết
+
+<http://127.0.0.1:4000>
+
+## Chú thích cuối trang
+
+Nhấp vào móc sẽ định vị chú thích cuối trang[^footnote], và đây là một chú thích cuối trang khác[^fn-nth-2].
+
+## Mã nội dòng
+
+Đây là ví dụ về `Mã Nội Dòng`.
+
+## Đường dẫn file
+
+Đây là `/path/to/the/file.extend`{: .filepath}.
+
+## Khối mã
+
+### Thông thường
+
+```text
+Đây là một đoạn mã thông thường, không có tô sáng cú pháp và số dòng.
+```
+
+### Ngôn ngữ cụ thể
+
+```bash
+if [ $? -ne 0 ]; then
+  echo "Lệnh không thành công.";
+  #thực hiện hành động cần thiết / thoát
+fi;
+```
+
+### Tên file cụ thể
+
+```sass
+@import
+  "colors/light-typography",
+  "colors/dark-typography";
+```
+
+{: file='_sass/jekyll-theme-chirpy.scss'}
+
+## Toán học
+
+Toán học được hỗ trợ bởi [**MathJax**](https://www.mathjax.org/):
+
+$$
+\begin{equation}
+  \sum_{n=1}^\infty 1/n^2 = \frac{\pi^2}{6}
+  \label{eq:series}
+\end{equation}
+$$
+
+Chúng ta có thể tham chiếu phương trình như \eqref{eq:series}.
+
+Khi $a \ne 0$, có hai nghiệm cho $ax^2 + bx + c = 0$ và chúng là
+
+$$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
+
+## Mermaid SVG
+
+```mermaid
+ gantt
+  title  Thêm chức năng biểu đồ GANTT vào mermaid
+  apple :a, 2017-07-20, 1w
+  banana :crit, b, 2017-07-23, 1d
+  cherry :active, c, after b a, 1d
+```
+
+## Hình ảnh
+
+### Mặc định (có chú thích)
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mockup.png){: width="972" height="589" }
+_Chiều rộng toàn màn hình và căn giữa_
+
+### Căn trái
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mockup.png){: width="972" height="589" .w-75 .normal}
+
+### Nổi về bên trái
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mockup.png){: width="972" height="589" .w-50 .left}
+Praesent maximus aliquam sapien. Sed vel neque in dolor pulvinar auctor. Maecenas pharetra, sem sit amet interdum posuere, tellus lacus eleifend magna, ac lobortis felis ipsum id sapien. Proin ornare rutrum metus, ac convallis diam volutpat sit amet. Phasellus volutpat, elit sit amet tincidunt mollis, felis mi scelerisque mauris, ut facilisis leo magna accumsan sapien. In rutrum vehicula nisl eget tempor. Nullam maximus ullamcorper libero non maximus. Integer ultricies velit id convallis varius. Praesent eu nisl eu urna finibus ultrices id nec ex. Mauris ac mattis quam. Fusce aliquam est nec sapien bibendum, vitae malesuada ligula condimentum.
+
+### Nổi về bên phải
+
+![Desktop View](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/mockup.png){: width="972" height="589" .w-50 .right}
+Praesent maximus aliquam sapien. Sed vel neque in dolor pulvinar auctor. Maecenas pharetra, sem sit amet interdum posuere, tellus lacus eleifend magna, ac lobortis felis ipsum id sapien. Proin ornare rutrum metus, ac convallis diam volutpat sit amet. Phasellus volutpat, elit sit amet tincidunt mollis, felis mi scelerisque mauris, ut facilisis leo magna accumsan sapien. In rutrum vehicula nisl eget tempor. Nullam maximus ullamcorper libero non maximus. Integer ultricies velit id convallis varius. Praesent eu nisl eu urna finibus ultrices id nec ex. Mauris ac mattis quam. Fusce aliquam est nec sapien bibendum, vitae malesuada ligula condimentum.
+
+### Chế độ Tối/Sáng & Đổ bóng
+
+Hình ảnh bên dưới sẽ chuyển đổi chế độ tối/sáng dựa trên tùy chọn giao diện, lưu ý nó có bóng.
+
+![light mode only](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/devtools-light.png){: .light .w-75 .shadow .rounded-10 w='1212' h='668' }
+![dark mode only](https://minixium-bucket.hn.ss.bfcplatform.vn/blog/posts/devtools-dark.png){: .dark .w-75 .shadow .rounded-10 w='1212' h='668' }
+
+## Video
+
+{% include embed/youtube.html id='hKMF9LXlO7w' %}
+
+## Chú thích cuối trang đảo ngược
+
+[^footnote]: Nguồn chú thích cuối trang
+[^fn-nth-2]: Nguồn chú thích cuối trang thứ 2

--- a/src/content/posts/video-vi.md
+++ b/src/content/posts/video-vi.md
@@ -1,0 +1,29 @@
+---
+lang: vi
+title: Nhúng Video trong Bài Viết
+published: 2023-08-01
+description: Bài viết này hướng dẫn cách nhúng video vào bài viết blog.
+tags: [Example, Video]
+category: Examples
+draft: false
+---
+
+Chỉ cần sao chép mã nhúng từ YouTube hoặc các nền tảng khác và dán vào file markdown.
+
+```yaml
+---
+title: Nhúng Video trong Bài Viết
+published: 2023-10-19
+// ...
+---
+
+<iframe width="100%" height="468" src="https://www.youtube.com/embed/5gIf0_xpFPI?si=N1WTorLKL0uwLsU_" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+```
+
+## YouTube
+
+<iframe width="100%" height="468" src="https://www.youtube.com/embed/5gIf0_xpFPI?si=N1WTorLKL0uwLsU_" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Bilibili
+
+<iframe width="100%" height="468" src="//player.bilibili.com/player.html?bvid=BV1fK4y1s7Qf&p=1" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"> </iframe>

--- a/src/content/posts/write-a-new-post-vi.md
+++ b/src/content/posts/write-a-new-post-vi.md
@@ -1,0 +1,522 @@
+---
+lang: vi
+title: Viết Bài Viết Mới
+author: minhpt
+description: >-
+  Viết bài viết mới với Jekyll, sử dụng Markdown
+published: 2025-02-05
+categories: hosted
+tags: [blog, tutorial, github, jekyll, chirpy, self-hosted]
+render_with_liquid: false
+---
+
+Hướng dẫn này sẽ chỉ cho bạn cách viết bài trong mẫu _Chirpy_, và rất đáng đọc ngay cả khi bạn đã sử dụng Jekyll trước đây, vì nhiều tính năng yêu cầu các biến cụ thể phải được thiết lập.
+
+## Đặt tên và Đường dẫn
+
+Tạo một file mới có tên `YYYY-MM-DD-TIEUDE.PHANDUOI`{: .filepath} và đặt nó vào thư mục `_posts`{: .filepath} của thư mục gốc. Xin lưu ý rằng `PHANDUOI`{: .filepath} phải là một trong `md`{: .filepath} và `markdown`{: .filepath}. Nếu bạn muốn tiết kiệm thời gian tạo file, hãy cân nhắc sử dụng plugin [`Jekyll-Compose`](https://github.com/jekyll/jekyll-compose).
+
+## Front Matter
+
+Về cơ bản, bạn cần điền [Front Matter](https://jekyllrb.com/docs/front-matter/) như sau ở đầu bài viết:
+
+```yaml
+---
+title: TIEU_DE
+date: YYYY-MM-DD HH:MM:SS +/-TTTT
+categories: [DANH_MUC_CHINH, DANH_MUC_PHU]
+tags: [THE]     # Tên TAG luôn ở dạng chữ thường
+---
+```
+
+> _Layout_ của bài viết đã được đặt mặc định là `post`, vì vậy không cần thêm biến _layout_ trong khối Front Matter.
+{: .prompt-tip }
+
+### Múi giờ của Ngày
+
+Để ghi lại chính xác ngày xuất bản của bài viết, bạn không chỉ nên thiết lập `timezone` trong `_config.yml`{: .filepath} mà còn cung cấp múi giờ của bài viết trong biến `date` của khối Front Matter. Định dạng: `+/-TTTT`, ví dụ: `+0800`.
+
+### Danh mục và Thẻ
+
+`categories` của mỗi bài viết được thiết kế để chứa tối đa hai phần tử, và số lượng phần tử trong `tags` có thể từ không đến vô hạn. Ví dụ:
+
+```yaml
+---
+categories: [Animal, Insect]
+tags: [bee]
+---
+```
+
+### Thông tin Tác giả
+
+Thông tin tác giả của bài viết thường không cần điền trong _Front Matter_, chúng sẽ được lấy từ biến `social.name` và mục đầu tiên của `social.links` trong file cấu hình theo mặc định. Nhưng bạn cũng có thể ghi đè như sau:
+
+Thêm thông tin tác giả trong `_data/authors.yml` (Nếu website của bạn không có file này, đừng ngần ngại tạo một file mới).
+
+```yaml
+<author_id>:
+  name: <tên đầy đủ>
+  twitter: <twitter_của_tác_giả>
+  url: <trang_chủ_của_tác_giả>
+```
+
+{: file="_data/authors.yml" }
+
+Và sau đó sử dụng `author` để chỉ định một mục hoặc `authors` để chỉ định nhiều mục:
+
+```yaml
+---
+author: <author_id>                     # cho một mục
+# hoặc
+authors: [<author1_id>, <author2_id>]   # cho nhiều mục
+---
+```
+
+Tuy nhiên, khóa `author` cũng có thể xác định nhiều mục.
+
+> Lợi ích của việc đọc thông tin tác giả từ file `_data/authors.yml`{: .filepath } là trang sẽ có thẻ meta `twitter:creator`, giúp làm phong phú [Twitter Cards](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#card-and-content-attribution) và tốt cho SEO.
+{: .prompt-info }
+
+### Mô tả Bài viết
+
+Theo mặc định, những từ đầu tiên của bài viết được sử dụng để hiển thị trên trang chủ cho danh sách bài viết, trong phần _Further Reading_ và trong XML của RSS feed. Nếu bạn không muốn hiển thị mô tả tự động tạo cho bài viết, bạn có thể tùy chỉnh nó bằng trường `description` trong _Front Matter_ như sau:
+
+```yaml
+---
+description: Tóm tắt ngắn của bài viết.
+---
+```
+
+Ngoài ra, văn bản `description` cũng sẽ được hiển thị dưới tiêu đề bài viết trên trang của bài viết.
+
+## Mục lục
+
+Theo mặc định, **M**ục **l**ục (TOC) được hiển thị trên bảng điều khiển bên phải của bài viết. Nếu bạn muốn tắt nó trên toàn cầu, hãy vào `_config.yml`{: .filepath} và đặt giá trị của biến `toc` thành `false`. Nếu bạn muốn tắt TOC cho một bài viết cụ thể, hãy thêm vào [Front Matter](https://jekyllrb.com/docs/front-matter/) của bài viết:
+
+```yaml
+---
+toc: false
+---
+```
+
+## Bình luận
+
+Cài đặt toàn cầu cho bình luận được xác định bởi tùy chọn `comments.provider` trong file `_config.yml`{: .filepath}. Khi một hệ thống bình luận được chọn cho biến này, bình luận sẽ được kích hoạt cho tất cả bài viết.
+
+Nếu bạn muốn tắt bình luận cho một bài viết cụ thể, hãy thêm vào **Front Matter** của bài viết:
+
+```yaml
+---
+comments: false
+---
+```
+
+## Media
+
+Chúng tôi gọi hình ảnh, âm thanh và video là tài nguyên media trong _Chirpy_.
+
+### Tiền tố URL
+
+Đôi khi chúng ta phải xác định các tiền tố URL trùng lặp cho nhiều tài nguyên trong một bài viết, đó là một công việc nhàm chán mà bạn có thể tránh bằng cách đặt hai tham số.
+
+- Nếu bạn đang sử dụng CDN để lưu trữ file media, bạn có thể chỉ định `cdn` trong `_config.yml`{: .filepath }. URL của tài nguyên media cho avatar site và bài viết sau đó sẽ được thêm tiền tố là tên miền CDN.
+
+  ```yaml
+  cdn: https://cdn.com
+  ```
+
+  {: file='_config.yml' .nolineno }
+
+- Để chỉ định tiền tố đường dẫn tài nguyên cho phạm vi bài viết/trang hiện tại, hãy đặt `media_subpath` trong _front matter_ của bài viết:
+
+  ```yaml
+  ---
+  media_subpath: /path/to/media/
+  ---
+  ```
+
+  {: .nolineno }
+
+Tùy chọn `site.cdn` và `page.media_subpath` có thể được sử dụng riêng lẻ hoặc kết hợp để linh hoạt tạo URL tài nguyên cuối cùng: `[site.cdn/][page.media_subpath/]file.ext`
+
+### Hình ảnh
+
+#### Chú thích
+
+Thêm chữ nghiêng vào dòng tiếp theo của hình ảnh, nó sẽ trở thành chú thích và xuất hiện ở cuối hình ảnh:
+
+```markdown
+![img-description](/path/to/image)
+_Chú thích Hình ảnh_
+```
+
+{: .nolineno}
+
+#### Kích thước
+
+Để ngăn bố cục nội dung trang bị dịch chuyển khi hình ảnh được tải, chúng ta nên đặt chiều rộng và chiều cao cho mỗi hình ảnh.
+
+```markdown
+![Desktop View](/assets/img/sample/mockup.png){: width="700" height="400" }
+```
+
+{: .nolineno}
+
+> Đối với SVG, bạn phải chỉ định ít nhất _chiều rộng_ của nó, nếu không nó sẽ không được hiển thị.
+{: .prompt-info }
+
+Bắt đầu từ _Chirpy v5.0.0_, `height` và `width` hỗ trợ viết tắt (`height` → `h`, `width` → `w`). Ví dụ sau có cùng hiệu quả như trên:
+
+```markdown
+![Desktop View](/assets/img/sample/mockup.png){: w="700" h="400" }
+```
+
+{: .nolineno}
+
+#### Vị trí
+
+Theo mặc định, hình ảnh được căn giữa, nhưng bạn có thể chỉ định vị trí bằng cách sử dụng một trong các lớp `normal`, `left` và `right`.
+
+> Khi vị trí được chỉ định, không nên thêm chú thích hình ảnh.
+{: .prompt-warning }
+
+- **Vị trí bình thường**
+
+  Hình ảnh sẽ được căn trái trong ví dụ dưới đây:
+
+  ```markdown
+  ![Desktop View](/assets/img/sample/mockup.png){: .normal }
+  ```
+
+  {: .nolineno}
+
+- **Nổi về bên trái**
+
+  ```markdown
+  ![Desktop View](/assets/img/sample/mockup.png){: .left }
+  ```
+
+  {: .nolineno}
+
+- **Nổi về bên phải**
+
+  ```markdown
+  ![Desktop View](/assets/img/sample/mockup.png){: .right }
+  ```
+
+  {: .nolineno}
+
+#### Chế độ Tối/Sáng
+
+Bạn có thể làm cho hình ảnh tuân theo tùy chọn giao diện ở chế độ tối/sáng. Điều này yêu cầu bạn chuẩn bị hai hình ảnh, một cho chế độ tối và một cho chế độ sáng, sau đó gán cho chúng một lớp cụ thể (`dark` hoặc `light`):
+
+```markdown
+![Light mode only](/path/to/light-mode.png){: .light }
+![Dark mode only](/path/to/dark-mode.png){: .dark }
+```
+
+#### Đổ bóng
+
+Ảnh chụp màn hình cửa sổ chương trình có thể được xem xét để hiển thị hiệu ứng đổ bóng:
+
+```markdown
+![Desktop View](/assets/img/sample/mockup.png){: .shadow }
+```
+
+{: .nolineno}
+
+#### Hình ảnh Xem trước
+
+Nếu bạn muốn thêm hình ảnh ở đầu bài viết, hãy cung cấp hình ảnh với độ phân giải `1200 x 630`. Xin lưu ý rằng nếu tỷ lệ khung hình của hình ảnh không đáp ứng `1.91 : 1`, hình ảnh sẽ được thay đổi tỷ lệ và cắt xén.
+
+Biết được các điều kiện tiên quyết này, bạn có thể bắt đầu đặt thuộc tính của hình ảnh:
+
+```yaml
+---
+image:
+  path: /path/to/image
+  alt: văn bản thay thế hình ảnh
+---
+```
+
+Lưu ý rằng [`media_subpath`](#url-prefix) cũng có thể được truyền cho hình ảnh xem trước, nghĩa là khi nó đã được đặt, thuộc tính `path` chỉ cần tên file hình ảnh.
+
+Để sử dụng đơn giản, bạn cũng có thể chỉ sử dụng `image` để xác định đường dẫn.
+
+```yml
+---
+image: /path/to/image
+---
+```
+
+#### LQIP
+
+Cho hình ảnh xem trước:
+
+```yaml
+---
+image:
+  lqip: /path/to/lqip-file # hoặc base64 URI
+---
+```
+
+> Bạn có thể quan sát LQIP trong hình ảnh xem trước của bài viết "[Text and Typography](../text-and-typology/)".
+
+Cho hình ảnh thông thường:
+
+```markdown
+![Image description](/path/to/image){: lqip="/path/to/lqip-file" }
+```
+
+{: .nolineno }
+
+### Video
+
+#### Nền tảng Mạng xã hội
+
+Bạn có thể nhúng video từ các nền tảng mạng xã hội với cú pháp sau:
+
+```liquid
+{% include embed/{Platform}.html id='{ID}' %}
+```
+
+Trong đó `Platform` là tên viết thường của nền tảng và `ID` là ID của video.
+
+Bảng sau đây cho thấy cách lấy hai tham số chúng ta cần từ một URL video cụ thể và bạn cũng có thể biết các nền tảng video hiện được hỗ trợ.
+
+| URL Video                                                                                          | Nền tảng   | ID             |
+| -------------------------------------------------------------------------------------------------- | ---------- | :------------- |
+| [https://www.**youtube**.com/watch?v=**H-B46URT4mg**](https://www.youtube.com/watch?v=H-B46URT4mg) | `youtube`  | `H-B46URT4mg`  |
+| [https://www.**twitch**.tv/videos/**1634779211**](https://www.twitch.tv/videos/1634779211)         | `twitch`   | `1634779211`   |
+| [https://www.**bilibili**.com/video/**BV1Q44y1B7Wf**](https://www.bilibili.com/video/BV1Q44y1B7Wf) | `bilibili` | `BV1Q44y1B7Wf` |
+
+#### File Video
+
+Nếu bạn muốn nhúng trực tiếp một file video, hãy sử dụng cú pháp sau:
+
+```liquid
+{% include embed/video.html src='{URL}' %}
+```
+
+Trong đó `URL` là URL đến file video, ví dụ: `/path/to/sample/video.mp4`.
+
+Bạn cũng có thể chỉ định các thuộc tính bổ sung cho file video được nhúng. Đây là danh sách đầy đủ các thuộc tính được phép.
+
+- `poster='/path/to/poster.png'` — hình ảnh áp phích cho video hiển thị khi video đang tải
+- `title='Text'` — tiêu đề cho video xuất hiện bên dưới video và trông giống như cho hình ảnh
+- `autoplay=true` — video tự động bắt đầu phát lại ngay khi có thể
+- `loop=true` — tự động quay lại đầu khi kết thúc video
+- `muted=true` — âm thanh sẽ bị tắt ban đầu
+- `types` — chỉ định phần mở rộng của các định dạng video bổ sung được phân tách bằng `|`. Đảm bảo các file này tồn tại trong cùng thư mục với file video chính của bạn.
+
+Xem xét một ví dụ sử dụng tất cả những điều trên:
+
+```liquid
+{%
+  include embed/video.html
+  src='/path/to/video.mp4'
+  types='ogg|mov'
+  poster='poster.png'
+  title='Video demo'
+  autoplay=true
+  loop=true
+  muted=true
+%}
+```
+
+### Âm thanh
+
+Nếu bạn muốn nhúng trực tiếp một file âm thanh, hãy sử dụng cú pháp sau:
+
+```liquid
+{% include embed/audio.html src='{URL}' %}
+```
+
+Trong đó `URL` là URL đến file âm thanh, ví dụ: `/path/to/audio.mp3`.
+
+Bạn cũng có thể chỉ định các thuộc tính bổ sung cho file âm thanh được nhúng. Đây là danh sách đầy đủ các thuộc tính được phép.
+
+- `title='Text'` — tiêu đề cho âm thanh xuất hiện bên dưới âm thanh và trông giống như cho hình ảnh
+- `types` — chỉ định phần mở rộng của các định dạng âm thanh bổ sung được phân tách bằng `|`. Đảm bảo các file này tồn tại trong cùng thư mục với file âm thanh chính của bạn.
+
+Xem xét một ví dụ sử dụng tất cả những điều trên:
+
+```liquid
+{%
+  include embed/audio.html
+  src='/path/to/audio.mp3'
+  types='ogg|wav|aac'
+  title='Âm thanh demo'
+%}
+```
+
+## Bài viết Ghim
+
+Bạn có thể ghim một hoặc nhiều bài viết lên đầu trang chủ và các bài viết được ghim sẽ được sắp xếp theo thứ tự ngược lại dựa trên ngày xuất bản. Kích hoạt bằng:
+
+```yaml
+---
+pin: true
+---
+```
+
+## Lời nhắc
+
+Có một số loại lời nhắc: `tip`, `info`, `warning` và `danger`. Chúng có thể được tạo bằng cách thêm lớp `prompt-{type}` vào blockquote. Ví dụ, xác định lời nhắc loại `info` như sau:
+
+```md
+> Dòng ví dụ cho lời nhắc.
+{: .prompt-info }
+```
+
+{: .nolineno }
+
+## Cú pháp
+
+### Mã Nội dòng
+
+```md
+`phần mã nội dòng`
+```
+
+{: .nolineno }
+
+### Đánh dấu Đường dẫn File
+
+```md
+`/path/to/a/file.extend`{: .filepath}
+```
+
+{: .nolineno }
+
+### Khối Mã
+
+Ký hiệu Markdown ```` ``` ```` có thể dễ dàng tạo khối mã như sau:
+
+````md
+```
+Đây là một đoạn mã văn bản thường.
+```
+````
+
+#### Chỉ định Ngôn ngữ
+
+Sử dụng ```` ```{ngôn_ngữ} ```` bạn sẽ nhận được khối mã có tô sáng cú pháp:
+
+````markdown
+```yaml
+key: value
+```
+````
+
+> Thẻ Jekyll `{% highlight %}` không tương thích với theme này.
+{: .prompt-danger }
+
+#### Số dòng
+
+Theo mặc định, tất cả ngôn ngữ ngoại trừ `plaintext`, `console` và `terminal` sẽ hiển thị số dòng. Khi bạn muốn ẩn số dòng của khối mã, hãy thêm lớp `nolineno` vào nó:
+
+````markdown
+```shell
+echo 'Không còn số dòng nữa!'
+```
+{: .nolineno }
+````
+
+#### Chỉ định Tên File
+
+Bạn có thể nhận thấy rằng ngôn ngữ mã sẽ được hiển thị ở đầu khối mã. Nếu bạn muốn thay thế nó bằng tên file, bạn có thể thêm thuộc tính `file` để đạt được điều này:
+
+````markdown
+```shell
+# nội dung
+```
+{: file="path/to/file" }
+````
+
+#### Mã Liquid
+
+Nếu bạn muốn hiển thị đoạn mã **Liquid**, hãy bao quanh mã liquid bằng `{% raw %}` và `{% endraw %}`:
+
+````markdown
+{% raw %}
+```liquid
+{% if product.title contains 'Pack' %}
+  Tiêu đề sản phẩm này chứa từ Pack.
+{% endif %}
+```
+{% endraw %}
+````
+
+Hoặc thêm `render_with_liquid: false` (Yêu cầu Jekyll 4.0 trở lên) vào khối YAML của bài viết.
+
+## Toán học
+
+Chúng tôi sử dụng [**MathJax**][mathjax] để tạo toán học. Vì lý do hiệu suất website, tính năng toán học sẽ không được tải theo mặc định. Nhưng nó có thể được kích hoạt bằng:
+
+[mathjax]: https://www.mathjax.org/
+
+```yaml
+---
+math: true
+---
+```
+
+Sau khi kích hoạt tính năng toán học, bạn có thể thêm phương trình toán học với cú pháp sau:
+
+- **Toán học khối** nên được thêm với `$$ toán $$` với các dòng trống **bắt buộc** trước và sau `$$`
+  - **Chèn đánh số phương trình** nên được thêm với `$$\begin{equation} toán \end{equation}$$`
+  - **Tham chiếu đánh số phương trình** nên được thực hiện với `\label{eq:label_name}` trong khối phương trình và `\eqref{eq:label_name}` nội dòng với văn bản (xem ví dụ dưới đây)
+- **Toán học nội dòng** (trong dòng) nên được thêm với `$$ toán $$` không có bất kỳ dòng trống nào trước hoặc sau `$$`
+- **Toán học nội dòng** (trong danh sách) nên được thêm với `\$$ toán $$`
+
+```markdown
+<!-- Toán học khối, giữ tất cả các dòng trống -->
+
+$$
+Biểu_thức_LaTeX
+$$
+
+<!-- Đánh số phương trình, giữ tất cả các dòng trống  -->
+
+$$
+\begin{equation}
+  Biểu_thức_LaTeX
+  \label{eq:label_name}
+\end{equation}
+$$
+
+Có thể được tham chiếu như \eqref{eq:label_name}.
+
+<!-- Toán học nội dòng trong dòng, KHÔNG có dòng trống -->
+
+"Lorem ipsum dolor sit amet, $$ Biểu_thức_LaTeX $$ consectetur adipiscing elit."
+
+<!-- Toán học nội dòng trong danh sách, thoát `$` đầu tiên -->
+
+1. \$$ Biểu_thức_LaTeX $$
+2. \$$ Biểu_thức_LaTeX $$
+3. \$$ Biểu_thức_LaTeX $$
+```
+
+> Bắt đầu từ `v7.0.0`, các tùy chọn cấu hình cho **MathJax** đã được chuyển đến file `assets/js/data/mathjax.js`{: .filepath } và bạn có thể thay đổi các tùy chọn khi cần, chẳng hạn như thêm [tiện ích mở rộng][mathjax-exts].  
+> Nếu bạn đang xây dựng site qua `chirpy-starter`, hãy sao chép file đó từ thư mục cài đặt gem (kiểm tra bằng lệnh `bundle info --path jekyll-theme-chirpy`) vào cùng thư mục trong kho lưu trữ của bạn.
+{: .prompt-tip }
+
+[mathjax-exts]: https://docs.mathjax.org/en/latest/input/tex/extensions/index.html
+
+## Mermaid
+
+[**Mermaid**](https://github.com/mermaid-js/mermaid) là một công cụ tạo sơ đồ tuyệt vời. Để kích hoạt nó trên bài viết của bạn, hãy thêm vào khối YAML:
+
+```yaml
+---
+mermaid: true
+---
+```
+
+Sau đó, bạn có thể sử dụng nó như các ngôn ngữ markdown khác: bao quanh mã sơ đồ bằng ```` ```mermaid ```` và ```` ``` ````.
+
+## Tìm hiểu thêm
+
+Để biết thêm kiến thức về bài viết Jekyll, hãy truy cập [Jekyll Docs: Posts](https://jekyllrb.com/docs/posts/).


### PR DESCRIPTION
## Vietnamese Translations for All EN Blog Posts

This PR adds Vietnamese (lang: vi) versions for all English blog posts.

### Stats:
- **65 new Vietnamese files** created across 7 batches
- **0 English files modified** — only new `-vi.md` files added
- Each file has `lang: vi`, translated title/description/tags/body

### Coverage:
- All Self-host posts → Vietnamese
- All tutorial/misc posts → Vietnamese
- All open-source-crm posts → Vietnamese
- Remaining posts (open-source-self-hosted, text-and-typo, video, write-a-new-post) → Vietnamese

### URL Structure:
- EN: `/en/posts/slug`
- VI: `/vi/posts/slug`

### Notes:
- Translations are faithful, no added content
- Original English files untouched
- Vietnamese SEO metadata included

**Ready to merge and deploy.**