### PR TITLE
Series Day 2: Firecrawl MCP Guide (EN + VI) — web scraping with 13 tools, real workflows

### DIFF
--- a/src/content/posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026-vi.md
+++ b/src/content/posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026-vi.md
@@ -1,0 +1,192 @@
+---
+lang: vi
+title: "Firecrawl MCP Server: Web Scraping & Search Cho AI Coding Agent"
+description: "Hướng dẫn toàn diện Firecrawl MCP (110K★ GitHub). Biến bất kỳ website nào thành dữ liệu sạch cho LLM. Cài đặt chi tiết, 13+ tools gồm scrape, search, crawl, map, deep research. Ví dụ thực tế: đọc docs, nghiên cứu đối thủ, xây RAG knowledge base."
+published: 2026-05-04
+category: AI
+tags: ["MCP", "Firecrawl", "Web Scraping", "Claude Code", "AI Agents", "Developer Tools", "Tutorial", "RAG"]
+author: minhpt
+mermaid: false
+---
+
+AI agent có thể code hoàn hảo nhưng không đọc được trang web — như đầu bếp nấu giỏi nhưng không order được nguyên liệu. **Firecrawl MCP Server** giải quyết vấn đề này: nó cho AI agent khả năng scrape, search, và xử lý bất kỳ website nào thành dữ liệu có cấu trúc.
+
+Với 110K+ GitHub stars, Firecrawl là một trong những MCP server được triển khai rộng rãi nhất trong production. Nó chạy cho mọi thứ từ documentation scraper tự động đến competitive research agent.
+
+---
+
+## Firecrawl MCP Là Gì?
+
+Firecrawl là nền tảng web scraping mã nguồn mở dành riêng cho AI/LLM consumption. MCP server của nó expose 13+ tools cho phép bất kỳ MCP-compatible AI client nào:
+
+- **Scrape** URL thành markdown sạch (bỏ quảng cáo, nav, clutter)
+- **Search** web với full page content
+- **Crawl** toàn bộ website theo link structure
+- **Map** architecture của website (khám phá tất cả paths)
+- **Deep research** với autonomous agent tổng hợp nhiều nguồn
+- **Tương tác trang** — click buttons, điền form, điều hướng
+
+---
+
+## Cài Đặt
+
+### Bước 1: Lấy API Key
+
+1. Đăng ký tại [firecrawl.dev](https://www.firecrawl.dev)
+2. Lấy API key từ dashboard: `https://www.firecrawl.dev/app/api-keys`
+
+Firecrawl có free tier (500 pages/tháng) — đủ cho personal use.
+
+### Bước 2: Cài đặt
+
+**Claude Code (npx):**
+```bash
+claude mcp add firecrawl \
+  --env FIRECRAWL_API_KEY=fc-YOUR_API_KEY \
+  -- npx -y firecrawl-mcp
+```
+
+**Remote URL (đơn giản nhất — không cần local process):**
+```bash
+claude mcp add firecrawl \
+  --transport http \
+  firecrawl https://mcp.firecrawl.dev/YOUR_API_KEY/v2/mcp
+```
+
+**Cursor (`.cursor/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "firecrawl-mcp": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "fc-YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Bước 3: Verify
+
+```bash
+# Trong Claude Code
+claude "Scrape https://example.com và tóm tắt"
+# Hoặc search
+claude "Search thông tin về Flutter 4.0 mới nhất"
+```
+
+---
+
+## 13+ Tools
+
+| Tool | Chức năng | Use Case |
+|---|---|---|
+| **firecrawl_scrape** | Scrape URL thành markdown | Tra cứu docs nhanh |
+| **firecrawl_batch_scrape** | Scrape nhiều URL cùng lúc | Research nhiều trang |
+| **firecrawl_crawl** | Crawl toàn bộ website | Documentation sites |
+| **firecrawl_search** | Web search với full content | Tìm thông tin mới |
+| **firecrawl_map** | Khám phá tất cả URLs trên site | Site architecture |
+| **firecrawl_deep_research** | Research đa nguồn tự động | Competitive analysis |
+| **firecrawl_extract** | Trích xuất dữ liệu có cấu trúc | Bảng giá, thông số |
+| **firecrawl_click** | Click elements | Login flows |
+| **firecrawl_screenshot** | Chụp screenshot | Xác minh trực quan |
+| **firecrawl_session** | Quản lý browser sessions | Persistent auth |
+
+---
+
+## Workflows Thực Tế
+
+### Workflow 1: Documentation Scraper
+
+```bash
+$ claude "Tôi cần dùng Stripe Checkout API.
+   Scrape docs và tạo usage example."
+
+Agent:
+  1. Scrape docs.stripe.com/api/checkout/sessions
+  2. Scrape docs.stripe.com/payments/checkout
+  3. Tổng hợp: "Cách dùng Stripe Checkout:
+     - Tạo session qua /v1/checkout/sessions
+     - Required params: line_items, mode, success_url, cancel_url
+     - Ví dụ code Node.js: ..."
+```
+
+### Workflow 2: Competitive Research
+
+```bash
+$ claude "Research 3 alternatives cho Vercel để host Next.js."
+
+Agent:
+  1. Search → "Next.js hosting alternatives 2026"
+  2. Extract → bảng giá từ top 5 kết quả
+  3. Deep research → "So sánh Vercel vs Netlify vs Railway"
+  4. Build bảng so sánh:
+     | Platform | Price | Next.js | Edge | Speed |
+     | Vercel | $20/mo | Native | Yes | 5s |
+     | Netlify | $19/mo | Plugin | Yes | 8s |
+```
+
+### Workflow 4: Build RAG Knowledge Base
+
+```bash
+$ claude "Xây knowledge base từ docs Tailwind CSS."
+
+Agent:
+  1. Map → tailwindcss.com/docs → phát hiện 200+ doc pages
+  2. Crawl → scrape 200 pages thành markdown
+  3. Ghi mỗi page thành file riêng
+  4. Sẵn sàng cho vector embedding
+```
+
+---
+
+## Firecrawl vs. Các Cách Khác
+
+| Phương pháp | Pros | Cons |
+|---|---|---|
+| **Firecrawl MCP** | LLM-ready, tương tác browser, deep research | Cần API key, rate limits |
+| **Paste URL thủ công** | Free, không setup | Chậm, ngắt flow |
+| **curl/wget** | Free, scriptable | Raw HTML, không LLM-optimized |
+
+---
+
+## Self-Hosting
+
+Firecrawl mã nguồn mở, có thể self-host qua Docker:
+
+```bash
+git clone https://github.com/firecrawl/firecrawl
+cd firecrawl && docker compose up
+```
+
+Config MCP server trỏ tới self-hosted instance:
+```json
+{
+  "mcpServers": {
+    "firecrawl-selfhosted": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "fc-selfhosted-key",
+        "FIRECRAWL_BASE_URL": "http://localhost:3002"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Tổng Kết
+
+Firecrawl MCP là web-reader thiết yếu cho AI agents. Nó biến web từ "bạn phải copy-paste" thành "để tôi fetch và analyze cho bạn."
+
+**Cài nó thứ hai — ngay sau GitHub MCP.** Với cả hai, agent có thể đọc codebase (GitHub MCP) và cả internet (Firecrawl MCP). Mọi thứ khác là additive.
+
+Bài tiếp theo: **Context7 MCP** — fix stale LLM training data bằng cách inject docs mới nhất.
+
+---
+
+*Series: Practical MCP Servers for Developers — 2026 Edition. Day 2 of 6.*

--- a/src/content/posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026.md
+++ b/src/content/posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026.md
@@ -1,0 +1,275 @@
+---
+lang: en
+title: "Firecrawl MCP Server: Web Scraping & Search for AI Coding Agents"
+description: "Complete guide to Firecrawl MCP (110K★ GitHub). Turn any website into clean, LLM-ready data. Covers installation, 13+ tools including scrape, crawl, search, map, deep research. Real examples: scraping competitor docs, monitoring pricing pages, building documentation RAG."
+published: 2026-05-04
+category: AI
+tags: ["MCP", "Firecrawl", "Web Scraping", "Claude Code", "AI Agents", "Developer Tools", "Tutorial", "RAG"]
+author: minhpt
+mermaid: false
+---
+
+An AI agent that can generate perfect code but can't read a webpage is like a chef who can cook anything but can't order ingredients. The **Firecrawl MCP Server** fixes this — it gives your AI agent the ability to scrape, search, and process any website into structured data.
+
+With 110K+ GitHub stars, Firecrawl is one of the most widely deployed MCP servers in production. It powers everything from automated documentation scrapers to competitive research agents to personalized news digests.
+
+---
+
+## What Is Firecrawl MCP?
+
+Firecrawl is an open-source web scraping platform specifically designed for AI/LLM consumption. Its MCP server exposes 13+ tools that let any MCP-compatible AI client:
+
+- **Scrape** any URL into clean, LLM-ready markdown (strips ads, nav, clutter)
+- **Search** the web with full page content returned
+- **Crawl** entire websites following link structures
+- **Map** a website's architecture (discover all paths)
+- **Deep research** with autonomous agent to synthesize across multiple sources
+- **Interact with pages** — click buttons, fill forms, navigate
+
+**Without Firecrawl MCP:**
+```bash
+$ claude "Read the docs for Library X and tell me how to install it"
+  → Agent: "I can't access the internet directly. Can you paste the docs?"
+  ← You: manually copy-paste from the docs site
+```
+
+**With Firecrawl MCP:**
+```bash
+$ claude "Read the docs for Library X and tell me how to install it"
+  → Agent: *scrapes Library X's documentation site*
+  → "npm install library-x. Then add this to your config..."
+```
+
+---
+
+## Installation
+
+### Step 1: Get an API Key
+
+1. Sign up at [firecrawl.dev](https://www.firecrawl.dev)
+2. Get your API key from the dashboard: `https://www.firecrawl.dev/app/api-keys`
+
+Firecrawl offers a free tier (500 pages/month) — enough for personal use and evaluation.
+
+### Step 2: Install
+
+**Claude Code (npx method):**
+```bash
+claude mcp add firecrawl \
+  --env FIRECRAWL_API_KEY=fc-YOUR_API_KEY \
+  -- npx -y firecrawl-mcp
+```
+
+**Remote URL (simplest — no local process):**
+```bash
+claude mcp add firecrawl \
+  --transport http \
+  firecrawl https://mcp.firecrawl.dev/YOUR_API_KEY/v2/mcp
+```
+
+**Cursor (`.cursor/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "firecrawl-mcp": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "fc-YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+**VS Code + Copilot (`.vscode/mcp.json`):**
+Same JSON structure as Cursor.
+
+### Step 3: Verify
+
+```bash
+# In Claude Code
+claude "Scrape https://example.com and summarize it"
+# Or search
+claude "Search the web for latest Flutter 4.0 release notes"
+```
+
+---
+
+## The 13+ Tools
+
+Firecrawl exposes a comprehensive set of tools:
+
+| Tool | What It Does | Use Case |
+|---|---|---|
+| **firecrawl_scrape** | Scrape a single URL into markdown | Quick doc lookup |
+| **firecrawl_batch_scrape** | Scrape multiple URLs in one batch | Multi-page research |
+| **firecrawl_crawl** | Crawl an entire website | Documentation sites |
+| **firecrawl_search** | Web search with full page content | Finding latest info |
+| **firecrawl_map** | Discover all URLs on a site | Site architecture |
+| **firecrawl_deep_research** | Autonomous multi-source research | Competitive analysis |
+| **firecrawl_extract** | Extract structured data from pages | Pricing tables, specs |
+| **firecrawl_click** | Click elements on a page | Login flows, navigation |
+| **firecrawl_fill** | Fill form fields | Search forms, signups |
+| **firecrawl_screenshot** | Capture page screenshots | Visual verification |
+| **firecrawl_session** | Manage browser sessions | Persistent auth |
+
+---
+
+## Real-World Workflows
+
+### Workflow 1: Documentation Scraper for AI Context
+
+The most common use case — feeding documentation into your AI agent's context:
+
+```bash
+$ claude "I need to use the Stripe Checkout API. 
+   Scrape their docs and create a usage example."
+
+Agent:
+  1. firecrawl_scrape → https://docs.stripe.com/api/checkout/sessions
+  2. firecrawl_scrape → https://docs.stripe.com/payments/checkout
+  3. firecrawl_scrape → https://docs.stripe.com/api/checkout/errors
+  4. Synthesizes: "Here's how Stripe Checkout works:
+     - Create a session via /v1/checkout/sessions
+     - Required params: line_items, mode, success_url, cancel_url
+     - Example code in Node.js: ..."
+```
+
+**Save this as a Skill for repeat use:**
+```markdown
+# /fetch-docs Skill
+
+When asked about a library or API:
+1. Firecrawl_scrape the official docs homepage
+2. Firecrawl_map to discover all doc paths
+3. Crawl the relevant section
+4. Return a structured summary with code examples
+```
+
+### Workflow 2: Competitive Research
+
+```bash
+$ claude "Research three alternatives to Vercel for Next.js hosting."
+
+Agent:
+  1. firecrawl_search → "Next.js hosting alternatives 2026"
+  2. firecrawl_extract → pricing tables from the top 5 results
+  3. firecrawl_deep_research → "Compare Vercel vs Netlify vs Railway"
+  4. Builds a comparison table:
+     | Platform | Price | Next.js Support | Edge Functions | Deploy Speed |
+     |---|---|---|---|---|
+     | Vercel | $20/mo | Native | Yes | 5s |
+     | Netlify | $19/mo | Plugin | Yes | 8s |
+     | Railway | $5/mo | Container | No | 12s |
+```
+
+### Workflow 3: Monitoring + Reporting
+
+```bash
+$ claude "Every morning, scrape Hacker News front page and synthesize the 
+   top 5 AI-tagged stories into a summary."
+
+Agent runs daily (via cron + Skill):
+  1. firecrawl_scrape → news.ycombinator.com (filter: AI tagged)
+  2. firecrawl_scrape → each story's content
+  3. Synthesizes: "Today's AI highlights:
+     - MCP SDK hits 100M downloads
+     - New model: Claude Opus 4.5 released
+     - Microsoft open-sources VibeVoice 2.0"
+```
+
+### Workflow 4: Building a RAG Knowledge Base
+
+```bash
+$ claude "I need to build a searchable knowledge base from the Tailwind CSS docs."
+
+Agent:
+  1. firecrawl_map → tailwindcss.com/docs → discovers 200+ doc pages
+  2. firecrawl_crawl → scrapes all 200 pages into markdown
+  3. Writes each page to a separate file
+  4. Saves to a local docs folder → ready for vector embedding
+```
+
+---
+
+## Firecrawl vs. Other Approaches
+
+| Method | Pros | Cons |
+|---|---|---|
+| **Firecrawl MCP** | LLM-ready output, browser interaction, deep research | API key needed, rate limits |
+| **manually paste URL content** | Free, no setup | Slow, breaks agent flow |
+| **curl/wget** | Free, scriptable | Raw HTML, no LLM optimization |
+| **Browser Use MCP** | Full browser control | Heavier, slower |
+| **Brave Search MCP** | Pure search, lightweight | No page interaction |
+
+---
+
+## Security Considerations
+
+Firecrawl is a read-scraping tool by nature, but:
+
+1. **API key management**: Store `FIRECRAWL_API_KEY` as an environment variable, never hardcode in config files
+2. **Rate limits respect**: The free tier is 500 pages/month. Monitor usage to avoid surprises
+3. **Prompt injection risk**: Since Firecrawl returns web content, a malicious website could inject instructions into the agent's context. This is primarily an issue if your agent has write-access to systems. Mitigation: keep write scopes separate
+4. **Self-hosting option**: Firecrawl is fully open-source. You can self-host it behind your own infrastructure for complete control
+
+---
+
+## Self-Hosting
+
+Firecrawl is fully open-source and can be self-hosted via Docker:
+
+```bash
+git clone https://github.com/firecrawl/firecrawl
+cd firecrawl
+docker compose up
+```
+
+Then configure the MCP server to point to your self-hosted instance:
+```json
+{
+  "mcpServers": {
+    "firecrawl-selfhosted": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "fc-selfhosted-key",
+        "FIRECRAWL_BASE_URL": "http://localhost:3002"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+**"Scrape returns empty content"**
+- Check if the site blocks scrapers (Cloudflare, bot detection)
+- Try with `--allow-bots` flag or self-hosted Chrome
+- The site might be JavaScript-rendered — use crawl instead of scrape
+
+**"Rate limit exceeded"**
+- Wait or upgrade your plan
+- Reduce crawl depth
+- Use search instead of scrape where possible
+
+**"Deep research takes too long"**
+- The autonomous research agent visits multiple pages — this is expected
+- Try narrow queries: "Compare X vs Y on pricing only"
+
+---
+
+## Summary
+
+Firecrawl MCP is the essential web-reader for AI agents. It transforms the web from "you'll have to copy-paste that" to "let me fetch and analyze that for you."
+
+**Install it second — right after GitHub MCP.** Between the two, your agent can read your codebase (GitHub MCP) and the entire internet (Firecrawl MCP). Everything else is additive.
+
+Next in this series: **Context7 MCP** — fixing stale LLM training data by injecting the latest docs.
+
+---
+
+*Series: Practical MCP Servers for Developers — 2026 Edition. Day 2 of 6.*


### PR DESCRIPTION
## MCP Server Series — Day 2

Firecrawl MCP (110K★ GitHub): turn any website into clean, LLM-ready data.

### What's in this post:
- What Firecrawl MCP does: 13+ tools for scrape, search, crawl, map, deep research
- Installation: npx, remote URL, Cursor, VS Code — all 3 methods
- Real workflows: docs scraper, competitive research, monitoring, RAG KB
- Comparison table: Firecrawl vs Brave Search vs Browser Use vs curl
- Self-hosting via Docker for complete control
- Security: prompt injection risks from scraped web content

### Files:
- `posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026.md` (EN)
- `posts/firecrawl-mcp-web-scraping-search-ai-agents-guide-2026-vi.md` (VI)

### Category: AI

**No auto-merge.** Day 2 of 6. Remaining: Context7, Playwright, PostgreSQL, Figma.