### PR TITLE
Series Day 6: Figma MCP Guide (EN + VI) — design-to-code with AI agents (Finale)

### DIFF
--- a/src/content/posts/figma-mcp-design-to-code-ai-agent-guide-2026-vi.md
+++ b/src/content/posts/figma-mcp-design-to-code-ai-agent-guide-2026-vi.md
@@ -1,0 +1,143 @@
+---
+lang: vi
+title: "Figma MCP Server: Từ Design Đến Code Với AI Agent — Hướng Dẫn Chi Tiết"
+description: "Hướng dẫn Figma MCP Server chính thức. Kết nối AI agent trực tiếp với Figma design files — đọc layer structures, auto-layout, variants, design tokens, và generate production code. Cầu nối giữa design và development giờ đã tự động."
+published: 2026-05-04
+category: AI
+tags: ["MCP", "Figma", "Design-to-Code", "Claude Code", "AI Agents", "Developer Tools", "Tutorial", "Frontend"]
+author: minhpt
+mermaid: false
+---
+
+Design-to-code handoff luôn là phần đau đớn nhất của frontend development. Bạn nhìn Figma file, extract thủ công colors, text styles, spacing, Auto Layout rules, rồi translate thành code. Tốn thời gian, dễ sai, và không ai thích.
+
+**Figma MCP Server chính thức** thay đổi điều này. Nó cho AI agent access trực tiếp vào design files — layer structure, Auto Layout, variants, design tokens, component properties — và tự động generate production code từ design data thực tế.
+
+---
+
+## Cài Đặt
+
+### Remote OAuth (Đơn giản nhất)
+
+```bash
+claude mcp add figma \
+  --transport http \
+  figma-remote-mcp https://mcp.figma.com/mcp
+```
+
+Sau đó restart Claude Code, chạy `/mcp`, chọn `figma-remote-mcp` và OAuth qua browser.
+
+### Personal Access Token (Local)
+
+Tạo Figma PAT tại `Settings → Account → Personal Access Tokens`:
+
+```bash
+claude mcp add figma \
+  --env FIGMA_ACCESS_TOKEN=figd_your_token \
+  -- npx -y figma-mcp-server
+```
+
+### Cursor
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-mcp-server"],
+      "env": {
+        "FIGMA_ACCESS_TOKEN": "figd_your_token_here"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Tools Overview
+
+| Tool | Chức năng |
+|---|---|
+| **figma_get_file** | File metadata và page list |
+| **figma_get_page** | Tất cả frames và components trên page |
+| **figma_get_node** | Chi tiết node cụ thể (layer, frame, component) |
+| **figma_get_styles** | Tất cả design styles (colors, text, effects) |
+| **figma_get_component** | Component details và instances |
+| **figma_search_nodes** | Search nodes theo tên |
+| **figma_get_image** | Export URLs cho node images |
+
+---
+
+## Workflows Thực Tế
+
+### Workflow 1: Design-to-Code
+
+```bash
+$ claude "Login screen mới trong Figma file 'Sprint-42'.
+   Generate React component."
+
+Agent:
+  1. Đọc file, tìm "Login Screen" page
+  2. Lấy frames: login-container, email-input, submit-button
+  3. Extract design tokens: colors, typography, spacing
+  4. Đọc Auto Layout rules
+  5. Generate React component với exact styles
+```
+
+### Workflow 2: Design Token Extraction
+
+```bash
+$ claude "Extract tất cả design tokens và gen Tailwind config."
+
+Agent:
+  1. figma_get_styles → đọc colors, typography, effects
+  2. figma_get_component → đọc variants
+  3. Gen tailwind.config.ts với tokens chính xác
+```
+
+### Workflow 3: Component Variant Coverage
+
+```bash
+$ claude "Check Button component có đủ required states không?"
+
+Agent:
+  So sánh Figma variants (default, hover, active, disabled, loading)
+  với codebase hiện tại
+  → "Missing: hover, active, loading. Generating code cho 3 states."
+```
+
+---
+
+## Token Costs
+
+| Operation | Token Cost |
+|---|---|
+| Get file info (5 pages) | 1,000 - 3,000 |
+| Get page details (1 complex page) | 5,000 - 15,000 |
+| Get single node | 500 - 2,000 |
+| Get all styles | 3,000 - 10,000 |
+| Full screen gen | 10,000 - 40,000 |
+
+**Mẹo giảm cost:** Target specific nodes, extract styles 1 lần, dùng `figma_get_node` với specific IDs.
+
+---
+
+## Bảo Mật
+
+- **Scoped tokens**: PAT có thể scope tới specific files
+- **OAuth an toàn hơn**: Dùng short-lived tokens thay vì permanent PATs
+- **Read-only**: Figma MCP chỉ đọc, không modify files
+- **File keys nhạy cảm**: Giữ Figma file key khỏi public code
+
+---
+
+## Tổng Kết
+
+Figma MCP Server là cầu nối design-development mà frontend teams chờ đợi. Nó biến Dev Mode — vốn đã mạnh — thành thứ AI agent đọc và hành động tự động.
+
+**Pipeline design-to-code:** Figma MCP (đọc design) → Context7 (docs framework mới) → Agent (gen code) → GitHub MCP (tạo PR).
+
+---
+
+*Series: Practical MCP Servers for Developers — 2026 Edition. Day 6 of 6 — Series Complete.*

--- a/src/content/posts/figma-mcp-design-to-code-ai-agent-guide-2026.md
+++ b/src/content/posts/figma-mcp-design-to-code-ai-agent-guide-2026.md
@@ -1,0 +1,266 @@
+---
+lang: en
+title: "Figma MCP Server: From Design to Code with AI Agents — The Complete Guide"
+description: "Complete guide to the official Figma MCP Server. Connect your AI agent directly to your Figma design files — read layer structures, auto-layout, variants, design tokens, and generate production code. The bridge between design and development is now automated."
+published: 2026-05-04
+category: AI
+tags: ["MCP", "Figma", "Design-to-Code", "Claude Code", "AI Agents", "Developer Tools", "Tutorial", "Frontend"]
+author: minhpt
+mermaid: false
+---
+
+Design-to-code handoff has always been the most painful part of frontend development. You stare at a Figma file, manually extract colors, text styles, spacing, and Auto Layout rules, then translate them into code. It's tedious, error-prone, and nobody enjoys it.
+
+The **official Figma MCP Server** changes this. It gives your AI agent direct access to your design files — layer structure, Auto Layout, variants, design tokens, and component properties — and lets it generate production-ready code from the actual design data.
+
+---
+
+## What Is Figma MCP?
+
+The [official Figma MCP Server](https://developers.figma.com/docs/figma-mcp-server/) is maintained by Figma themselves. It exposes Dev Mode design information as MCP tools, allowing any AI client to read layer structures, properties, and design tokens from Figma files.
+
+**Before Figma MCP:**
+```bash
+You: "Build this login screen from Figma"
+
+  → Manually open Figma Dev Mode
+  → Read colors: copy hex values
+  → Read text styles: copy font sizes, weights
+  → Read spacing: measure gaps in Auto Layout
+  → Read component variants: check all states
+  → Write code, compare, iterate...
+  → 30-60 minutes for a simple screen
+```
+
+**With Figma MCP:**
+```bash
+$ claude "Build this login screen from our Figma design"
+  
+Agent:
+  1. Inspects the Figma file structure
+  2. Extracts: colors, typography, spacing, component variants
+  3. Generates complete React/Next.js code matching the design
+  4. Outputs: styled component with exact colors, spacing, and layout
+  
+  → 2-3 minutes from request to working UI
+```
+
+---
+
+## Installation
+
+### Prerequisites
+- A Figma file URL or file key you have access to
+- Figma OAuth (for remote method) or Personal Access Token (for local)
+
+### Method 1: Remote OAuth (Simplest)
+
+```bash
+claude mcp add figma \
+  --transport http \
+  figma-remote-mcp https://mcp.figma.com/mcp
+```
+
+After adding, restart Claude Code and run `/mcp`, select `figma-remote-mcp`. It will open a browser window for OAuth authentication.
+
+### Method 2: Personal Access Token (Local)
+
+Generate a Figma PAT at `Settings → Account → Personal Access Tokens`:
+
+```bash
+claude mcp add figma \
+  --env FIGMA_ACCESS_TOKEN=figd_your_token \
+  -- npx -y figma-mcp-server
+```
+
+### Method 3: Cursor
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-mcp-server"],
+      "env": {
+        "FIGMA_ACCESS_TOKEN": "figd_your_token_here"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Tools Overview
+
+| Tool | What It Does |
+|---|---|
+| **figma_get_file** | Get file metadata and page list |
+| **figma_get_page** | Get all frames and components on a page |
+| **figma_get_node** | Get detailed info about a specific node (layer, frame, component) |
+| **figma_get_image** | Get export URLs for node images |
+| **figma_search_nodes** | Search for nodes by name |
+| **figma_get_component** | Get component details and instances |
+| **figma_get_styles** | Get all design styles (colors, text, effects) |
+| **figma_get_file_comments** | Read comments on the file |
+
+---
+
+## Real-World Workflows
+
+### Workflow 1: Design-to-Code Conversion
+
+The core workflow. Give your agent a Figma file key and get React code:
+
+```bash
+$ claude "Our new login screen is in Figma file 'Sprint-42'.
+   Generate the React component."
+
+Agent:
+  1. figma_get_file → finds the "Login Screen" page
+  2. figma_get_page → discovers frames: login-container, 
+     email-input, password-input, submit-button, error-state
+  3. figma_get_styles → extracts tokens:
+     - Colors: primary (#2563EB), bg (#F8FAFC), error (#DC2626)
+     - Text: body-16 (Inter, 16px, 1.5), heading-24 (Inter, 24px, 700)
+     - Effects: shadow-sm on button
+  4. figma_get_node for each frame → extracts Auto Layout:
+     - login-container: vertical, padding 24px, gap 16px
+     - submit-button: horizontal, padding 12px 24px
+  5. Generates:
+     ```tsx
+     export function LoginScreen() {
+       return (
+         <div className="bg-[#F8FAFC] p-6 space-y-4">
+           <h1 className="font-inter text-2xl font-bold">Welcome Back</h1>
+           <InputField label="Email" />
+           <InputField label="Password" type="password" />
+           <Button className="bg-[#2563EB] shadow-sm">
+             Sign In
+           </Button>
+         </div>
+       );
+     }
+     ```
+
+---
+
+### Workflow 2: Design Token Extraction
+
+```bash
+$ claude "Extract all design tokens from our design system 
+   and generate a Tailwind config"
+
+Agent:
+  1. figma_get_styles → reads all colors, typography, 
+     spacing, and effect styles
+  2. figma_get_component → reads component variants
+  3. Generates tailwind.config.ts with exact tokens:
+     - Color palette from Figma color styles
+     - Font sizes from text styles
+     - Shadows from effect styles
+  4. Outputs: "Here's your Tailwind config matching the 
+     design system. I also mapped layer names to semantic tokens."
+```
+
+### Workflow 3: Component Variant Coverage
+
+```bash
+$ claude "Check if our Button component covers all required states"
+
+Agent:
+  1. figma_get_component → finds Button with variants:
+     default, hover, active, disabled, loading
+  2. Compares with current codebase:
+     - Code has: default, disabled
+     - Missing: hover, active, loading
+  3. Reports: "3 missing states. Generating code for each.
+     Also noticed: the Figma hover state uses 
+     `brightness(0.9)` which isn't in your current CSS."
+```
+
+### Workflow 4: Responsive Layout Verification
+
+```bash
+$ claude "Our dashboard has mobile and desktop versions in Figma.
+   Check if my responsive CSS matches."
+
+Agent:
+  1. Reads both frames: Dashboard-Desktop, Dashboard-Mobile
+  2. Compares Auto Layout differences:
+     - Desktop: 3-column grid, horizontal nav
+     - Mobile: 1-column stack, hamburger menu
+  3. Checks your CSS against these specs
+  4. "You're missing the mobile breakpoint for the sidebar.
+     At $lg, the sidebar should collapse to icons only.
+     Figma shows it at 64px wide instead of 240px."
+```
+
+---
+
+## Token Costs
+
+| Operation | Token Cost |
+|---|---|
+| Get file info (file with 5 pages) | 1,000 - 3,000 |
+| Get page details (1 complex page) | 5,000 - 15,000 |
+| Get single node details | 500 - 2,000 |
+| Get all styles | 3,000 - 10,000 |
+| Full screen generation | 10,000 - 40,000 |
+
+**Tips to reduce costs:**
+- Target specific nodes instead of scanning full pages
+- Extract styles once and reuse
+- Work with individual frames, not entire file pages
+- Use `figma_get_node` with specific IDs instead of `figma_get_page`
+
+---
+
+## Figma MCP vs. Other Approaches
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **Figma MCP** | Direct access, token-aware, component-aware, Auto Layout extraction | Token-heavy with complex files |
+| **Manual Dev Mode** | Full control, visual inspection | Slow, error-prone, manual |
+| **Screenshot → AI** | Quick, no configuration | No layer structure, inaccurate spacing |
+| **CodeGen plugins** | One-click, no AI needed | Rigid output, limited customization |
+
+---
+
+## Security
+
+1. **Scoped tokens**: Generate a PAT with minimum access. Figma PATs can be scoped to specific files
+2. **OAuth is safer**: The remote OAuth method uses short-lived tokens rather than permanent PATs
+3. **Read-only by nature**: Figma MCP is inherently read-only — it reads design data but can't modify files
+4. **File keys are sensitive**: A Figma file key exposes your design structure. Keep it out of public code
+
+---
+
+## Troubleshooting
+
+**"Can't access the file"** 
+- Check that your token has access to the file
+- Is the file within a team/enterprise that requires SSO?
+- Try the OAuth method instead of PAT
+
+**"Token costs are too high with complex files"**
+- Target specific frames: `figma_get_node <node_id>`
+- Don't call `figma_get_page` on pages with hundreds of frames
+- Run style extraction once and save the output
+
+**"The generated code doesn't match the design exactly"**
+- Figma MCP reads structural data but can't see exact pixel positioning
+- Complex overlapping layers may need manual adjustment
+- Use the screenshot tool (`figma_get_image`) alongside structural data for reference
+
+---
+
+## Summary
+
+Figma MCP Server is the bridge between design and development that frontend teams have been waiting for. It turns Figma's Dev Mode — which was already powerful — into something your AI agent can read and act on autonomously.
+
+**The design-to-code pipeline:** Figma MCP (read design) → Context7 (latest framework docs) → Agent (generate code) → GitHub MCP (create PR).
+
+***
+
+*Series: Practical MCP Servers for Developers — 2026 Edition. Day 6 of 6 — Series Complete.*


### PR DESCRIPTION
## MCP Server Series — Day 6 (Series Finale)

Figma MCP Server — the official bridge between design files and AI-generated code.

### What's in this post:
- 8 tools: get_file, get_page, get_node, get_styles, get_component...
- Installation: Remote OAuth (simplest), PAT, Cursor
- 4 workflows: design-to-code conversion, token extraction, variant coverage, responsive verification
- Token cost breakdown per operation
- Comparison: Figma MCP vs manual Dev Mode vs screenshot vs codegen plugins
- Series wrap-up with full pipeline

### Files:
- `posts/figma-mcp-design-to-code-ai-agent-guide-2026.md` (EN)
- `posts/figma-mcp-design-to-code-ai-agent-guide-2026-vi.md` (VI)

**No auto-merge.** Day 6 of 6 — Series Complete.