### PR TITLE
Series Day 4: Claude Agent SDK — MCP-Native Agent Toolkit (EN + VI)

### DIFF
--- a/src/content/posts/claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026-vi.md
+++ b/src/content/posts/claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026-vi.md
@@ -1,0 +1,196 @@
+---
+title: "Claude Agent SDK: Bộ công cụ Agent MCP-Native của Anthropic"
+description: "Tìm hiểu sâu về Claude Agent SDK — framework agent đẳng cấp đầu tiên của Anthropic với MCP native, tools-as-resources, computer use và agent loop pattern. Xây dựng agent MCP-native từ nền tảng."
+published: 2026-05-24
+pubDate: 2026-05-24T10:00:00.000Z
+slug: claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026-vi
+tags:
+  - claude
+  - anthropic
+  - agent-sdk
+  - mcp
+  - ai-agents
+  - agent-framework
+  - computer-use
+  - tool-use
+category: ai-agents
+lang: vi
+series:
+  name: "AI Agent Frameworks 2026 — So sánh Production"
+  order: 4
+  total: 6
+---
+
+LangGraph, CrewAI và AutoGen đều hỗ trợ MCP như một tính năng có thể plug-in. Claude Agent SDK khác: **MCP là nền tảng, không phải add-on.**
+
+Framework agent của Anthropic được xây dựng song song với spec MCP. Mọi agent trong SDK này nói MCP native — kết nối tools, đọc resources và quản lý prompts thông qua protocol. Nếu bạn đã theo dõi series MCP và Kiro của blog này, đây là framework được thiết kế từ đầu cho thế giới mà những bài đó mô tả.
+
+Ra mắt đầu năm 2026, Claude Agent SDK nằm dưới Claude Code trong product stack của Anthropic. Claude Code là trải nghiệm IDE đầy đủ. SDK là thứ bạn dùng để xây dựng agent của riêng mình, tự động hóa workflow và nhúng khả năng của Claude vào ứng dụng.
+
+---
+
+## Điều Gì Làm Nó Khác Biệt
+
+Ba quyết định thiết kế đặt Claude Agent SDK khác mọi framework khác:
+
+### 1. Kiến Trúc MCP-Native
+
+Mọi framework khác coi MCP là một tùy chọn tích hợp. Claude Agent SDK không có "MCP adapter" — agent loop tự nó giao tiếp qua MCP.
+
+```python
+from claude_agent import Agent, MCPConfig
+
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[
+        MCPConfig(command="npx", args=["-y", "@modelcontextprotocol/server-github"]),
+        MCPConfig(command="node", args=["./my-mcp-server/index.js"]),
+    ]
+)
+```
+
+Agent kết nối MCP servers khi khởi động. Tools được tự động phát hiện qua MCP `tools/list` endpoint. Không cần đăng ký tool thủ công, không decorators, không function wrapping.
+
+### 2. Tools là Resources, Không phải Functions
+
+```python
+# SDK: tool_use trả về MCP resource với structured content
+agent.use_tool("search_docs", {"query": "authentication flow"})
+# Trả về: typed content blocks (text, image, JSON)
+```
+
+Tools tạo typed content blocks thay vì raw strings. Agent suy luận về tool outputs chính xác hơn.
+
+### 3. Computer Use Built In
+
+SDK bao gồm khả năng `Computer` — tính năng cho phép Claude nhìn screenshot, di chuyển cursor và tương tác với desktop apps:
+
+```python
+from claude_agent.tools import Computer
+
+agent = Agent(
+    model="claude-sonnet-4",
+    tools=[Computer()]
+)
+```
+
+Hữu ích cho:
+- **Testing UI workflows** — QA tự động dùng interface thực
+- **Legacy system integration** — Tương tác hệ thống không API
+- **Desktop automation** — Quản lý file, điều khiển ứng dụng
+
+---
+
+## Kiến Trúc Cốt Lõi
+
+### Agent Loop
+
+```python
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[github_server, db_server, docs_server],
+    system_prompt="Bạn là DevOps engineer."
+)
+
+response = await agent.run("Deploy bản build mới nhất lên staging")
+```
+
+Bạn có thể hook vào loop:
+
+```python
+agent.on("tool_call", lambda tool, args: log_tool_usage(tool, args))
+agent.on("tool_result", lambda result: validate_output(result))
+```
+
+### Memory
+
+```python
+from claude_agent import Agent, FileMemory, PostgresMemory
+
+agent = Agent(memory=FileMemory(path="./agent_memory"))
+agent = Agent(memory=PostgresMemory(connection_string=os.getenv("DB_URL")))
+```
+
+Memory lưu: conversation history, preferences, tool output cache, session state.
+
+### Thinking Mode
+
+```python
+agent = Agent(model="claude-sonnet-4", thinking_budget=16000)
+
+result = await agent.run_with_thinking(
+    "Debug connection pool exhaustion",
+    stream_thinking=True
+)
+```
+
+---
+
+## Tool Composition
+
+```python
+from claude_agent import Tool, compose_tools
+
+@Tool
+def search_github_issues(repo: str, query: str): ...
+
+@Tool
+def read_issue(issue_url: str): ...
+
+incident_response = compose_tools(
+    "incident_response",
+    tools=[search_github_issues, read_issue],
+)
+
+agent.add_tool(incident_response)
+```
+
+Composed tool xuất hiện như một capability đơn lẻ. SDK orchestrate sub-tools.
+
+---
+
+## Claude Agent SDK vs Claude Code
+
+| | Claude Agent SDK | Claude Code |
+|--|-----------------|-------------|
+| **Mục đích** | Xây dựng agent tùy chỉnh | Coding tương tác |
+| **Interface** | Python SDK | Terminal / IDE |
+| **MCP** | Native | Plugin |
+| **Computer Use** | Có | Không |
+| **Custom logic** | Full control | Qua rules files |
+| **Triển khai** | Infrastructure của bạn | Terminal của Anthropic |
+
+Claude Code là sản phẩm shipped. SDK là thứ bạn build với.
+
+---
+
+## Khi Nào Chọn
+
+### Phù hợp
+- **Kiến trúc MCP-heavy** — Nhiều MCP servers, SDK xử lý native
+- **Computer Use workflows** — UI testing, desktop automation
+- **Stack chỉ Anthropic** — Claude là model provider duy nhất
+- **Custom agent loops** — Cần inspect, log, modify decision loop
+
+### Tránh khi
+- **Cần multi-model** — SDK chỉ Claude
+- **Team không dùng MCP** — SDK assume MCP
+- **Cần cross-repo orchestration** — Đó là lãnh thổ Kiro
+- **Team ưa LangChain** — SDK không integration với LangChain
+
+---
+
+## Tiếp Theo
+
+| Bài | Framework |
+|-----|-----------|
+| 1 | LangGraph |
+| 2 | CrewAI |
+| 3 | AutoGen |
+| 4 | **Claude Agent SDK** (bài này) |
+| 5 | OpenAI Agents SDK |
+| 6 | **So sánh cuối** |
+
+---
+
+*Series: AI Agent Frameworks 2026 — So sánh Production. Bài 4: Claude Agent SDK. Bài 5: OpenAI Agents SDK → sắp tới.*

--- a/src/content/posts/claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026.md
+++ b/src/content/posts/claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026.md
@@ -1,0 +1,290 @@
+---
+title: "Claude Agent SDK: Anthropic's MCP-Native Agent Toolkit"
+description: "Deep dive into the Claude Agent SDK — Anthropic's first-class agent framework with native MCP, tools-as-resources, computer use, and the agent loop pattern. Build agents that are MCP-native from the ground up."
+published: 2026-05-24
+pubDate: 2026-05-24T10:00:00.000Z
+slug: claude-agent-sdk-anthropic-mcp-native-agent-toolkit-2026
+tags:
+  - claude
+  - anthropic
+  - agent-sdk
+  - mcp
+  - ai-agents
+  - agent-framework
+  - computer-use
+  - tool-use
+category: ai-agents
+lang: en
+series:
+  name: "AI Agent Frameworks 2026 — Production Comparison"
+  order: 4
+  total: 6
+---
+
+LangGraph, CrewAI, and AutoGen all support MCP as a feature you can plug in. The Claude Agent SDK is different: **MCP is the foundation, not an add-on.**
+
+Anthropic's agent framework was built alongside the MCP specification. Every agent in this SDK speaks MCP natively — connecting tools, reading resources, and managing prompts through the protocol. If you've been following this blog's MCP series and Kiro series, this is the framework designed from the ground up for the world those posts described.
+
+Launched in early 2026, the Claude Agent SDK sits below Claude Code in Anthropic's product stack. Claude Code is the full IDE experience. The SDK is what you use to build your own agents, automate workflows, and embed Claude's capabilities into your applications.
+
+---
+
+## What Makes It Different
+
+Three design decisions set the Claude Agent SDK apart from every other framework:
+
+### 1. MCP-Native Architecture
+
+Every other framework treats MCP as one integration option among many. The Claude Agent SDK doesn't have an "MCP adapter" — the agent loop itself communicates through MCP.
+
+```python
+from claude_agent import Agent, MCPConfig
+
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[
+        MCPConfig(command="npx", args=["-y", "@modelcontextprotocol/server-github"]),
+        MCPConfig(command="node", args=["./my-mcp-server/index.js"]),
+    ]
+)
+```
+
+The agent connects to MCP servers at startup. Tools are discovered automatically through MCP's `tools/list` endpoint. There's no manual tool registration, no decorators, no function wrapping.
+
+### 2. Tools as Resources, Not Functions
+
+Most frameworks model tools as Python functions you call. The SDK models tools as **MCP resources** — structured data that tools produce and consume.
+
+```python
+# Other frameworks:
+@tool("search_docs")
+def search_docs(query: str) -> str:
+    return vector_store.search(query)
+
+# Claude Agent SDK:
+# MCP server exposes search_docs as a tool automatically.
+# The agent's tool_use block describes it as a resource.
+agent.use_tool("search_docs", {"query": "authentication flow"})
+# Returns: MCP resource with structured content, not a string
+```
+
+This sounds like a detail, but it changes how you build agents. Tools produce typed content blocks (text, images, JSON, embedded resources) instead of raw strings. The agent can reason about tool outputs more precisely.
+
+### 3. Computer Use Built In
+
+The SDK includes a `Computer` capability — the same feature that lets Claude see screenshots, move cursors, and interact with desktop applications:
+
+```python
+from claude_agent.tools import Computer
+
+agent = Agent(
+    model="claude-sonnet-4",
+    tools=[Computer()]  # Direct UI interaction
+)
+```
+
+The `Computer` tool gives the agent a virtual screen, keyboard, and mouse. This is useful for:
+- **Testing UI workflows** — Automated QA that actually uses the interface
+- **Legacy system integration** — Interacting with systems that have no API
+- **Desktop automation** — File management, application control, data entry
+
+---
+
+## Core Architecture
+
+### The Agent Loop
+
+The SDK exposes a clean agent loop that you can inspect and customize:
+
+```python
+from claude_agent import Agent
+
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[github_server, db_server, docs_server],
+    system_prompt="You are a DevOps engineer. Use GitHub for PRs, DB for queries, docs for reference."
+)
+
+response = await agent.run("Deploy the latest build to staging")
+
+# The agent loop:
+# 1. Receives message → decides next action
+# 2. Calls MCP tools → receives structured results
+# 3. Reasons about results → decides next action
+# 4. Repeats until criteria met → returns final response
+```
+
+You can hook into the loop at any point:
+
+```python
+agent.on("tool_call", lambda tool, args: log_tool_usage(tool, args))
+agent.on("tool_result", lambda result: validate_output(result))
+agent.on("thinking", lambda thought: stream_to_ui(thought))
+```
+
+### Memory and State
+
+The SDK provides a `Memory` abstraction:
+
+```python
+from claude_agent import Agent, FileMemory, PostgresMemory
+
+# File-based for development
+agent = Agent(memory=FileMemory(path="./agent_memory"))
+
+# Postgres for production
+agent = Agent(memory=PostgresMemory(connection_string=os.getenv("DB_URL")))
+```
+
+Memory stores:
+- Conversation history (compressed per session)
+- User preferences and learned behaviors
+- Tool output cache (avoids redundant MCP calls)
+- Session state for human-in-the-loop pauses
+
+### Thinking Mode
+
+Built on Claude's extended thinking capability:
+
+```python
+agent = Agent(
+    model="claude-sonnet-4",
+    thinking_budget=16000  # tokens allocated to reasoning
+)
+
+result = await agent.run_with_thinking(
+    "Debug the database connection pool exhaustion",
+    stream_thinking=True  # See the reasoning process
+)
+```
+
+The agent shows its reasoning process before tool calls. This isn't a debug mode — it's the actual agent loop exposed.
+
+---
+
+## Tool Composition: Beyond Simple Functions
+
+The SDK supports tool composition — combining multiple tools into higher-level capabilities:
+
+```python
+from claude_agent import Tool, compose_tools
+
+@Tool
+def search_github_issues(repo: str, query: str):
+    """Search GitHub issues by keyword"""
+
+@Tool
+def read_issue(issue_url: str):
+    """Read full issue content"""
+
+@Tool
+def analyze_sentiment(text: str):
+    """Analyze sentiment of text"""
+
+# Compose into a higher-level tool
+incident_response = compose_tools(
+    "incident_response",
+    tools=[search_github_issues, read_issue, analyze_sentiment],
+    description="Search for incidents, analyze customer reports"
+)
+
+agent.add_tool(incident_response)
+```
+
+The composed tool appears as a single capability in the agent's tool set. The agent calls `incident_response` → the SDK orchestrates the sub-tools → returns a combined result.
+
+---
+
+## Production Patterns
+
+### Pattern 1: MCP-First Service Agent
+
+```python
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[
+        MCPConfig(command="node", args=["./mcp/github.js"]),
+        MCPConfig(command="node", args=["./mcp/datadog.js"]),
+        MCPConfig(command="node", args=["./mcp/pagerduty.js"]),
+        MCPConfig(command="node", args=["./mcp/kubernetes.js"]),
+    ],
+    system_prompt="""You are an SRE agent.
+    Available MCP servers provide access to:
+    - GitHub: PRs, issues, deployments
+    - Datadog: metrics, monitors, dashboards  
+    - PagerDuty: incidents, on-call schedules
+    - Kubernetes: pods, services, deployments
+    """
+)
+```
+
+The agent discovers 20+ tools automatically from these four MCP servers. No tool definitions to maintain.
+
+### Pattern 2: Research Agent with Computer Use
+
+```python
+agent = Agent(
+    model="claude-sonnet-4",
+    mcp_servers=[web_search, browser_mcp],
+    tools=[Computer()],
+    system_prompt="Research competitor products and document findings"
+)
+
+# The agent:
+# 1. Searches the web via MCP
+# 2. Opens browsers via Computer tool
+# 3. Takes screenshots of competitor UIs
+# 4. Captures data into structured resources
+# 5. Writes a research document
+```
+
+---
+
+## Claude Agent SDK vs Claude Code
+
+These are often confused. Here's the distinction:
+
+| | Claude Agent SDK | Claude Code |
+|--|-----------------|-------------|
+| **Purpose** | Build custom agents | Interactive coding |
+| **Interface** | Python SDK | Terminal / IDE |
+| **MCP** | Native | Plugin |
+| **Computer Use** | Yes | No |
+| **Custom logic** | Full control | Via rules files |
+| **Deployment** | Your infrastructure | Anthropic's terminal |
+| **Best for** | Automation, enterprise agents | Day-to-day coding |
+
+Claude Code is shipped. The SDK is what you build with.
+
+---
+
+## When to Choose Claude Agent SDK
+
+### Best Fit
+- **MCP-heavy architectures** — Your agent needs many MCP servers; the SDK handles them natively
+- **Computer Use workflows** — UI testing, desktop automation, legacy system interaction
+- **Anthropic-only stacks** — If your organization uses Claude as the sole model provider
+- **Custom agent loops** — When you need to inspect, log, or modify the agent's decision loop
+
+### Avoid When
+- **You need multi-model support** — The SDK is Claude-only. No Llama, GPT, Gemini.
+- **Your team doesn't use MCP** — The SDK assumes MCP; using it without MCP servers is wasteful
+- **You need cross-repo orchestration** — That's Kiro's territory, not the SDK
+- **Your team prefers LangChain** — The SDK has no LangChain integration; you'd be starting from scratch
+
+---
+
+## Next in the Series
+
+| Post | Framework |
+|------|-----------|
+| 1 | LangGraph |
+| 2 | CrewAI |
+| 3 | AutoGen |
+| 4 | **Claude Agent SDK** (this) |
+| 5 | OpenAI Agents SDK |
+| 6 | **Head-to-Head Comparison** |
+
+---
+
+*Series: AI Agent Frameworks 2026 — Production Comparison. Post 4: Claude Agent SDK. Post 5: OpenAI Agents SDK → coming next.*


### PR DESCRIPTION
## Series AI Agent Frameworks 2026 — Bài 4: Claude Agent SDK

**Nội dung:**
- MCP-native architecture: tools auto-discovered via MCP, không manual registration
- Tools as Resources (typed content blocks) vs tools as Functions
- Computer Use built-in: UI testing, desktop automation, legacy system interaction
- Agent loop: hookable, inspectable, customizable
- Memory abstraction: FileMemory, PostgresMemory
- Thinking mode: 16k token thinking budget, streaming reasoning
- Tool composition: compose_tools() combining multiple tools
- Production patterns: MCP-first SRE agent, Research agent with Computer Use
- Claude Agent SDK vs Claude Code comparison

✅ **No duplicate keys, no git corruption**

⚠️ **Không tự merge**