### PR TITLE
fix: Day 2 caching — invalidation scope, cost estimates, VI table sync

### DIFF
--- a/src/content/posts/ai-agents-in-production-caching-strategies-vi.md
+++ b/src/content/posts/ai-agents-in-production-caching-strategies-vi.md
@@ -352,11 +352,12 @@ curl http://localhost:3001/cache/stats
 
 | Data type | Layer | TTL | Cost saved |
 |-----------|-------|-----|------------|
-| LLM response | Semantic | 5 min | Token cost × 3-5x |
+| LLM response "what issues are open?" | Semantic | 5 min | Token cost × 3-5x |
 | Tool result (read) | Exact | 1 min | API rate limit |
 | Tool result (list) | Exact | 30s | API calls |
-| Mutation | None | — | — |
+| Mutation | None (0 TTL) | — | — |
 | Embedding | Semantic | 30 min | Embedding API cost |
+| System prompt | Manual prefetch | Session | Token cost daily |
 
 ---
 

--- a/src/content/posts/ai-agents-in-production-caching-strategies.md
+++ b/src/content/posts/ai-agents-in-production-caching-strategies.md
@@ -685,9 +685,11 @@ export class CacheOrchestrator {
     if (tool === "create_issue" || tool === "update_issue") {
       await this.exact.clear("tool:list_issues:*");
       await this.exact.clear("tool:search_issues:*");
+      await this.exact.clear("tool:get_issue:*");
 
-      // Semantic: clear recent entries
-      await this.semantic.clear("*");
+      // Semantic: only invalidate entries containing affected repo
+      const repoHint = params.repo ? `*${params.repo}*` : "*";
+      await this.semantic.clear(repoHint);
     }
   }
 
@@ -792,9 +794,9 @@ app.get("/cache/stats", async (req, res) => {
     hitRate: `${hitRate}%`,
     layers: stats,
     estimatedSavings: {
-      exact: `$${(stats.exact.hits * 0.002).toFixed(2)}`, // ~$0.002 saved per hit
-      semantic: `$${(stats.semantic.hits * 0.002).toFixed(2)}`,
-      tool: `$${(stats.tool.hits * 0.002).toFixed(2)}`,
+      exact: `$${(stats.exact.hits * 0.001).toFixed(3)}`, // ~$0.001 saved per exact hit
+      semantic: `$${(stats.semantic.hits * 0.005).toFixed(2)}`,
+      tool: `$${(stats.tool.hits * 0.003).toFixed(2)}`,
     },
   });
 });


### PR DESCRIPTION
Fix 3 issues from Day 2 review:

1. **Semantic cache invalidation**: `clear("*")` → `clear(repoHint)` — chỉ xoá entries liên quan tới repo bị mutate, không wipe sạch toàn bộ cache
2. **Cost estimate values**: exact $0.001, semantic $0.005, tool $0.003 — sát giá thực tế hơn (trước dùng $0.002 chung)
3. **VI table**: thêm dòng System prompt, đổi tiêu đề cột LLM response cho đồng bộ với EN

Adds `get_issue` to invalidation list too.

⚠️ **Do not auto-merge**