### PR TITLE
AWS for AI/Agent Developers — Day 1: Deploy MCP Server on ECS Fargate (EN + VI)

### DIFF
--- a/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate-vi.md
+++ b/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate-vi.md
@@ -21,11 +21,78 @@ series:
   total: 6
 ---
 
-Bạn xây MCP server. Nó chạy trên localhost. Giờ đưa lên internet để agent nào cũng gọi được.
+## Tổng quan Series
+
+AI agents rất mạnh, nhưng chạy production là chuyện khác. Cần infrastructure reliable, scalable, secure — và AWS giải quyết được tất cả.
+
+Series này dạy bạn **xây dựng production-grade infrastructure cho AI agents trên AWS**. Mỗi ngày là một piece của puzzle: deploy model, quản lý state, caching, routing traffic, và automate deployment.
+
+### Kiến trúc tổng thể — Chúng ta đang xây cái gì?
+
+```
+                           AI Agent trong Production
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          │                         │                         │
+          ▼                         ▼                         ▼
+    ┌──────────────┐        ┌──────────────┐         ┌──────────────┐
+    │ Route53 +    │        │   ALB        │         │ CI/CD        │
+    │ CloudFront   │        │ (Load Balancer)        │ Pipeline     │
+    │ (Day 5)      │        │ (Day 1)       │         │ (Day 6)      │
+    └──────┬───────┘        └──────┬───────┘         └──────────────┘
+           │                       │
+    ┌──────▼───────────────────────▼──────┐
+    │          Compute Layer              │
+    │  ┌────────────────┬──────────────┐  │
+    │  │ ECS Fargate   │  Lambda +    │  │
+    │  │ (Container)   │  Bedrock     │  │
+    │  │ (Day 1)       │  (Day 4)     │  │
+    │  └───────┬───────┴──────┬───────┘  │
+    └──────────┼──────────────┼──────────┘
+               │              │
+    ┌──────────▼──────────────▼──────────┐
+    │        Data Layer                  │
+    │  ┌──────────────┬──────────────┐   │
+    │  │ DynamoDB     │ ElastiCache  │   │
+    │  │ (State/SS)   │ (Cache/LLM)  │   │
+    │  │ (Day 2)      │ (Day 3)      │   │
+    │  └──────────────┴──────────────┘   │
+    └────────────────────────────────────┘
+```
+
+### Lộ trình 6 ngày
+
+| Day | Chủ đề | AWS Services | Học gì? |
+|-----|--------|-------------|---------|
+| 1 | Deploy MCP Server lên ECS Fargate | ECS, ECR, ALB, Secrets Manager | Containerize + deploy agent server với HTTPS, secrets, auto-scaling |
+| 2 | Agent State với DynamoDB | DynamoDB Global Tables, DAX | Lưu conversation history, session state, replication đa region |
+| 3 | LLM Caching với ElastiCache + Bedrock | ElastiCache (Redis), Bedrock | Semantic + prompt caching, giảm latency và cost |
+| 4 | Serverless Agent với Lambda + Bedrock | Lambda, API Gateway, Bedrock, Step Functions | Build agent không cần server |
+| 5 | Multi-Region Routing với Route53 | Route53, CloudFront, Global Accelerator | Global traffic routing, failover, latency-based |
+| 6 | CI/CD cho AI Agents | CodePipeline, CodeBuild, ECR, ECS | Automated deployment, zero-downtime ship |
+
+---
+
+## Day 1: Deploy MCP Server lên ECS Fargate
+
+Bạn xây MCP server. Nó chạy localhost. Giờ đưa lên internet để agent nào cũng gọi được.
 
 ECS Fargate là sweet spot: không quản lý EC2, auto-scaling sẵn, có load balancer built-in. Ship Docker image, Fargate lo phần còn lại.
 
-Bài này deploy MCP server lên ECS Fargate với ALB (HTTPS), Secrets Manager, auto-scaling, CI/CD.
+### Hôm nay deploy:
+
+```
+Agent ─▶ HTTPS :443 ─▶ ALB ─▶ ECS Fargate ─▶ MCP Server (Docker)
+```
+
+**Các bước:**
+1. Dockerize MCP server
+2. Push lên ECR
+3. Lưu secrets (GitHub token) vào Secrets Manager
+4. Tạo ECS Fargate cluster + task definition
+5. ALB với HTTPS
+6. Auto-scaling
+7. CI/CD tự động
 
 ---
 

--- a/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate-vi.md
+++ b/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate-vi.md
@@ -1,0 +1,224 @@
+---
+title: "AWS cho AI/Agent Developers — Day 1: Deploy MCP Server lên ECS Fargate"
+description: "Đưa MCP server từ localhost lên production trên AWS. ECS Fargate với ALB, auto-scaling, Secrets Manager, và CI/CD pipeline."
+published: 2026-06-26
+pubDate: 2026-06-26T02:00:00.000Z
+slug: aws-for-ai-agent-developers-deploy-mcp-ecs-fargate-vi
+tags:
+  - aws
+  - mcp
+  - ecs
+  - fargate
+  - docker
+  - ci-cd
+  - ai-agents
+  - infrastructure
+category: aws
+lang: vi
+series:
+  name: "AWS for AI/Agent Developers"
+  order: 1
+  total: 6
+---
+
+Bạn xây MCP server. Nó chạy trên localhost. Giờ đưa lên internet để agent nào cũng gọi được.
+
+ECS Fargate là sweet spot: không quản lý EC2, auto-scaling sẵn, có load balancer built-in. Ship Docker image, Fargate lo phần còn lại.
+
+Bài này deploy MCP server lên ECS Fargate với ALB (HTTPS), Secrets Manager, auto-scaling, CI/CD.
+
+---
+
+## Step 1: Dockerize
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+RUN addgroup -S mcp && adduser -S mcp -G mcp
+COPY --from=builder /app/node_modules ./node_modules
+COPY dist/ ./dist/
+COPY package.json ./
+USER mcp
+EXPOSE 3001
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
+ENV NODE_ENV=production PORT=3001
+CMD ["node", "dist/index.js"]
+```
+
+Multi-stage build: builder stage có devDependencies để compile, runtime chỉ có production code.
+
+---
+
+## Step 2: ECR
+
+```bash
+# Tạo repository với vulnerability scanning
+aws ecr create-repository \
+  --repository-name github-issue-mcp \
+  --image-scanning-configuration scanOnPush=true
+
+# Push image
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <account>.dkr.ecr.us-east-1.amazonaws.com
+docker push <account>.dkr.ecr.us-east-1.amazonaws.com/github-issue-mcp:latest
+```
+
+---
+
+## Step 3: Secrets Manager
+
+```bash
+aws secretsmanager create-secret \
+  --name "github-issue-mcp/github-token" \
+  --secret-string "ghp_your_token_here"
+```
+
+ECS injects secret vào container khi start. Không lưu trong image, không lưu trong git.
+
+---
+
+## Step 4: ECS Cluster + Service
+
+```bash
+# Cluster
+aws ecs create-cluster --cluster-name mcp-server-cluster \
+  --capacity-providers FARGATE FARGATE_SPOT
+
+# Task definition (CPU 256, RAM 512MB, secret từ Secrets Manager)
+aws ecs register-task-definition --family github-issue-mcp \
+  --network-mode awsvpc --requires-compatibilities FARGATE \
+  --cpu 256 --memory 512 \
+  --container-definitions '[
+    {"name":"mcp-server","image":"<account>.dkr.ecr.us-east-1.amazonaws.com/github-issue-mcp:latest",
+     "portMappings":[{"containerPort":3001}],
+     "secrets":[{"name":"GITHUB_TOKEN","valueFrom":"<secret-arn>"}],
+     "logConfiguration":{"logDriver":"awslogs","options":{"awslogs-group":"/ecs/github-issue-mcp"}}}
+  ]'
+
+# Service (2 tasks, private subnets, ALB attached)
+aws ecs create-service --cluster mcp-server-cluster \
+  --service-name github-issue-mcp --task-definition github-issue-mcp \
+  --desired-count 2 --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-private-a,subnet-private-b],securityGroups=[<task-sg>],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=<tg-arn>,containerName=mcp-server,containerPort=3001"
+```
+
+---
+
+## Step 5: ALB
+
+```
+Internet ─▶ HTTPS :443 ─▶ ALB ─▶ HTTP :3001 ─▶ ECS Task (private subnet)
+```
+- Security groups: ALB SG allow :443, Task SG allow :3001 từ ALB SG
+- Target group health check: GET /health
+- Cần ACM certificate cho HTTPS
+
+---
+
+## Step 6: Auto-Scaling
+
+```bash
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id service/mcp-server-cluster/github-issue-mcp \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 2 --max-capacity 20
+
+# Scale out khi request > 100/target
+aws application-autoscaling put-scaling-policy \
+  --service-namespace ecs \
+  --resource-id service/mcp-server-cluster/github-issue-mcp \
+  --scalable-dimension ecs:service:DesiredCount \
+  --policy-name request-count-target \
+  --policy-type TargetTrackingScaling \
+  --target-tracking-scaling-policy-configuration '{
+    "TargetValue": 100.0,
+    "PredefinedMetricSpecification": {
+      "PredefinedMetricType": "ALBRequestCountPerTarget"
+    }
+  }'
+```
+
+---
+
+## Step 7: CI/CD
+
+### buildspec.yml
+
+```yaml
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - npm ci && npm run build
+      - aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_REPOSITORY_URI
+  build:
+    commands:
+      - docker build -t $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION .
+      - docker tag $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION $ECR_REPOSITORY_URI:latest
+  post_build:
+    commands:
+      - docker push $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION
+      - printf '[{"name":"mcp-server","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION > imagedefinitions.json
+```
+
+Mỗi push lên main → build → push ECR → ECS deploy → ALB drain + route.
+
+---
+
+## Kết nối Agent
+
+```typescript
+const client = new McpClient({
+  transport: new SSEClientTransport({
+    url: "https://alb-dns/sse",
+    headers: { "Authorization": "Bearer <sse-secret>" },
+  }),
+});
+```
+
+---
+
+## Chi phí (~$69/tháng)
+
+| Component | Cost |
+|-----------|------|
+| Fargate (2 tasks) | ~$30 |
+| ALB | ~$22 |
+| ECR + Secrets + CW | ~$7 |
+| CodePipeline | ~$10 |
+| **Total** | **~$69** |
+
+---
+
+## Checklist
+
+- [ ] Dockerfile multi-stage
+- [ ] ECR scanOnPush
+- [ ] Secrets Manager
+- [ ] ECS task definition
+- [ ] ALB + HTTPS + health check
+- [ ] Auto-scaling
+- [ ] CodePipeline
+- [ ] CloudWatch dashboard
+
+---
+
+| Day | Chủ đề |
+|-----|--------|
+| 1 | **Deploy MCP Server lên ECS Fargate ✅** |
+| 2 | Agent State với DynamoDB Global Tables |
+| 3 | LLM Caching với ElastiCache + Bedrock |
+| 4 | Serverless Agent với Lambda + Bedrock |
+| 5 | Multi-Region Agent Routing với Route53 |
+| 6 | CI/CD cho AI Agents với CodePipeline |
+
+---
+
+*Series: AWS cho AI/Agent Developers. Day 1: Deploy MCP server lên ECS Fargate với ALB, Secrets Manager, auto-scaling, và CI/CD.*

--- a/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate.md
+++ b/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate.md
@@ -1,0 +1,443 @@
+---
+title: "AWS for AI/Agent Developers — Day 1: Deploy an MCP Server on ECS Fargate"
+description: "Take your MCP server from localhost to production on AWS. ECS Fargate with ALB, auto-scaling, Secrets Manager, and a CI/CD pipeline so shipping is one git push away."
+published: 2026-06-26
+pubDate: 2026-06-26T02:00:00.000Z
+slug: aws-for-ai-agent-developers-deploy-mcp-ecs-fargate
+tags:
+  - aws
+  - mcp
+  - ecs
+  - fargate
+  - docker
+  - ci-cd
+  - ai-agents
+  - infrastructure
+category: aws
+lang: en
+series:
+  name: "AWS for AI/Agent Developers"
+  order: 1
+  total: 6
+---
+
+You built an MCP server. It works on localhost. Now make it accessible to the internet — and to every agent that needs it.
+
+ECS Fargate is the sweet spot for serving MCP servers: no EC2 to manage, auto-scaling out of the box, and a built-in load balancer. You ship a Docker image, Fargate does the rest.
+
+This post deploys a GitHub Issue Manager MCP server onto AWS ECS Fargate, with:
+
+- Application Load Balancer (HTTPS + WebSocket for SSE transport)
+- Auto-scaling based on request count
+- Secrets Manager for GitHub tokens
+- ECR for Docker image storage
+- CI/CD via CodePipeline
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Agent      │────▶│   ALB        │────▶│   ECS         │
+│   (anywhere) │     │   (HTTPS)    │     │   Fargate     │
+├──────────────┤     ├──────────────┤     ├──────────────┤
+│  MCP Client  │     │  ┌────────┐ │     │  ┌──────────┐ │
+│  (SSE)       │     │  │ :443   │ │     │  │ MCP      │ │
+│              │     │  │ ─────▶ │ │     │  │ Server   │ │
+└──────────────┘     │  │ :3001  │ │     │  │ (Docker) │ │
+                     │  └────────┘ │     │  └──────────┘ │
+                     └──────────────┘     └──────────────┘
+```
+
+---
+
+## Prerequisites
+
+```bash
+# AWS CLI (logged in)
+aws configure
+
+# Docker
+docker --version
+
+# Node.js 18+
+node --version
+
+# An MCP server project. Any server with SSE transport works.
+```
+
+---
+
+## Step 1: Dockerize the MCP Server
+
+### `Dockerfile`
+
+```dockerfile
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+RUN addgroup -S mcp && adduser -S mcp -G mcp
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY dist/ ./dist/
+COPY package.json ./
+
+USER mcp
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+CMD ["node", "dist/index.js"]
+```
+
+Key points:
+- **Multi-stage build**: builder stage has devDependencies for compilation, runtime stays minimal
+- **Non-root user**: security best practice for containers
+- **Health check**: ECS uses this to determine container health
+- **No hardcoded tokens**: secrets are injected at runtime via Secrets Manager
+
+### Build and test locally:
+
+```bash
+docker build -t github-issue-mcp .
+docker run -p 3001:3001 \
+  -e GITHUB_TOKEN=your_token_here \
+  -e AWS_REGION=us-east-1 \
+  github-issue-mcp
+
+# Verify
+curl http://localhost:3001/health
+```
+
+---
+
+## Step 2: Set Up ECR Repository
+
+ECR is Docker Hub on AWS — private, fast, and integrated with ECS.
+
+```bash
+# Create repository with vulnerability scanning
+aws ecr create-repository \
+  --repository-name github-issue-mcp \
+  --image-scanning-configuration scanOnPush=true
+
+# Authenticate Docker
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin <account>.dkr.ecr.us-east-1.amazonaws.com
+
+# Tag and push
+docker tag github-issue-mcp:latest <account>.dkr.ecr.us-east-1.amazonaws.com/github-issue-mcp:latest
+docker push <account>.dkr.ecr.us-east-1.amazonaws.com/github-issue-mcp:latest
+```
+
+`scanOnPush=true` scans every pushed image for vulnerabilities before it reaches production.
+
+---
+
+## Step 3: Store Secrets in AWS Secrets Manager
+
+Never bake tokens into images. Never commit them to Git.
+
+```bash
+aws secretsmanager create-secret \
+  --name "github-issue-mcp/github-token" \
+  --description "GitHub Personal Access Token for MCP server" \
+  --secret-string "ghp_your_token_here"
+```
+
+Also store the SSE shared secret if you implemented authentication (from the MCP security series):
+
+```bash
+aws secretsmanager create-secret \
+  --name "github-issue-mcp/sse-shared-secret" \
+  --secret-string "your-sse-secret-here"
+```
+
+---
+
+## Step 4: Create ECS Cluster + Task Definition
+
+### Cluster
+
+```bash
+aws ecs create-cluster \
+  --cluster-name mcp-server-cluster \
+  --capacity-providers FARGATE FARGATE_SPOT
+```
+
+Using `FARGATE_SPOT` as secondary capacity saves 30-50% on compute costs.
+
+### Task Definition
+
+The task definition tells ECS what container to run, what ports to expose, and which secrets to inject.
+
+```bash
+GITHUB_TOKEN_ARN=$(aws secretsmanager describe-secret \
+  --secret-id "github-issue-mcp/github-token" --query ARN --output text)
+
+aws ecs register-task-definition \
+  --family github-issue-mcp \
+  --network-mode awsvpc \
+  --requires-compatibilities FARGATE \
+  --cpu 256 \
+  --memory 512 \
+  --execution-role-arn "arn:aws:iam::<account>:role/ecsTaskExecutionRole" \
+  --container-definitions '[
+    {
+      "name": "mcp-server",
+      "image": "<account>.dkr.ecr.us-east-1.amazonaws.com/github-issue-mcp:latest",
+      "essential": true,
+      "portMappings": [{"containerPort": 3001, "protocol": "tcp"}],
+      "environment": [
+        {"name": "NODE_ENV", "value": "production"},
+        {"name": "AWS_REGION", "value": "us-east-1"}
+      ],
+      "secrets": [
+        {"name": "GITHUB_TOKEN", "valueFrom": "'"$GITHUB_TOKEN_ARN"'"}
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/github-issue-mcp",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]'
+```
+
+The `execution-role-arn` references an IAM role that gives ECS permission to pull images from ECR and write logs to CloudWatch.
+
+---
+
+## Step 5: Create ALB + Service
+
+### Security groups
+
+```bash
+# ALB — receive HTTPS from anywhere
+aws ec2 create-security-group --group-name mcp-alb-sg --description "ALB for MCP server"
+aws ec2 authorize-security-group-ingress --group-id <alb-sg-id> \
+  --protocol tcp --port 443 --cidr 0.0.0.0/0
+
+# Tasks — receive traffic only from ALB
+aws ec2 create-security-group --group-name mcp-task-sg --description "MCP server tasks"
+aws ec2 authorize-security-group-ingress --group-id <task-sg-id> \
+  --protocol tcp --port 3001 --source-group <alb-sg-id>
+```
+
+### Target group and ALB
+
+```bash
+# Target group — health check on /health
+aws elbv2 create-target-group --name mcp-server-tg --protocol HTTP --port 3001 \
+  --target-type ip --vpc-id <vpc-id> --health-check-path /health
+
+# ALB
+aws elbv2 create-load-balancer --name mcp-server-alb \
+  --subnets subnet-<public-a> subnet-<public-b> --security-groups <alb-sg-id>
+
+# HTTPS listener (requires ACM certificate)
+aws elbv2 create-listener --load-balancer-arn <alb-arn> \
+  --protocol HTTPS --port 443 \
+  --certificates CertificateArn=<acm-cert-arn> \
+  --default-actions Type=forward,TargetGroupArn=<tg-arn>
+```
+
+### ECS Service
+
+```bash
+aws ecs create-service \
+  --cluster mcp-server-cluster \
+  --service-name github-issue-mcp \
+  --task-definition github-issue-mcp \
+  --desired-count 2 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-<private-a>,subnet-<private-b>],securityGroups=[<task-sg-id>],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=<tg-arn>,containerName=mcp-server,containerPort=3001" \
+  --deployment-configuration "maximumPercent=200,minimumHealthyPercent=100"
+```
+
+**Private subnets** + no public IP: the ALB handles all inbound traffic. The tasks only need outbound access to the GitHub API.
+
+---
+
+## Step 6: Auto-Scaling
+
+Scale on the metric that matters: request count per ALB target.
+
+```bash
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --resource-id service/mcp-server-cluster/github-issue-mcp \
+  --scalable-dimension ecs:service:DesiredCount \
+  --min-capacity 2 --max-capacity 20
+
+aws application-autoscaling put-scaling-policy \
+  --service-namespace ecs \
+  --resource-id service/mcp-server-cluster/github-issue-mcp \
+  --scalable-dimension ecs:service:DesiredCount \
+  --policy-name request-count-target \
+  --policy-type TargetTrackingScaling \
+  --target-tracking-scaling-policy-configuration '{
+    "TargetValue": 100.0,
+    "PredefinedMetricSpecification": {
+      "PredefinedMetricType": "ALBRequestCountPerTarget",
+      "ResourceLabel": "<alb-arn/tg-arn>"
+    },
+    "ScaleOutCooldown": 60,
+    "ScaleInCooldown": 120
+  }'
+```
+
+---
+
+## Step 7: CI/CD with CodePipeline
+
+### `buildspec.yml`
+
+```yaml
+version: 0.2
+phases:
+  install:
+    commands:
+      - npm ci
+  pre_build:
+    commands:
+      - npm run build
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_REPOSITORY_URI
+  build:
+    commands:
+      - docker build -t $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION .
+      - docker tag $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION $ECR_REPOSITORY_URI:latest
+  post_build:
+    commands:
+      - docker push $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION
+      - docker push $ECR_REPOSITORY_URI:latest
+      - printf '[{"name":"mcp-server","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$CODEBUILD_RESOLVED_SOURCE_VERSION > imagedefinitions.json
+artifacts:
+  files: imagedefinitions.json
+```
+
+Now every git push to `main` triggers:
+1. CodeBuild compiles TypeScript and builds the Docker image
+2. Pushes to ECR
+3. ECS deploys a new task definition with the updated image
+4. ALB gradually drains old connections and routes to new tasks
+
+---
+
+## Step 8: Connecting an Agent
+
+```typescript
+const client = new McpClient({
+  transport: new SSEClientTransport({
+    url: "https://mcp-server-<alb-dns>.us-east-1.elb.amazonaws.com/sse",
+    headers: {
+      "Authorization": "Bearer <sse-shared-secret>",
+    },
+  }),
+});
+```
+
+For SSE transport, enable stickiness on the ALB target group, or implement an external session store.
+
+---
+
+## Monitoring
+
+### Dashboard
+
+```bash
+aws cloudwatch put-dashboard --dashboard-name MCP-Server --dashboard-body '{
+  "widgets": [
+    {
+      "type": "metric",
+      "properties": {
+        "metrics": [
+          ["AWS/ECS", "CPUUtilization", {"stat": "Average"}],
+          ["AWS/ECS", "MemoryUtilization", {"stat": "Average"}]
+        ],
+        "period": 300, "stat": "Average", "region": "us-east-1",
+        "title": "MCP Server Resource Usage"
+      }
+    },
+    {
+      "type": "metric",
+      "properties": {
+        "metrics": [
+          ["AWS/ApplicationELB", "RequestCount", {"stat": "Sum"}],
+          ["AWS/ApplicationELB", "TargetResponseTime", {"stat": "p95"}],
+          ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", {"stat": "Sum"}]
+        ],
+        "period": 300, "region": "us-east-1",
+        "title": "ALB Metrics"
+      }
+    }
+  ]
+}'
+```
+
+---
+
+## Cost Breakdown
+
+| Component | Configuration | Monthly |
+|-----------|--------------|---------|
+| ECS Fargate | 2 tasks × 256/512 | ~$30 |
+| ALB | 1 ALB | ~$22 |
+| ECR | < 5GB storage | ~$1 |
+| Secrets Manager | 2 secrets | ~$1 |
+| CloudWatch | Logs + metrics | ~$5 |
+| CodePipeline | 50+ builds | ~$10 |
+| **Total** | | **~$69/mo** |
+
+With FARGATE_SPOT for 50% of tasks: ~$50/mo.
+
+---
+
+## What We Used
+
+| AWS Service | Purpose |
+|-------------|---------|
+| **ECR** | Private Docker registry |
+| **Secrets Manager** | GitHub tokens, SSE shared secret |
+| **ECS Fargate** | Serverless container runtime |
+| **ALB** | HTTPS termination + routing + auto-scaling |
+| **Application Auto Scaling** | Scale on request count |
+| **CodePipeline + CodeBuild** | CI/CD from git push |
+| **CloudWatch** | Logs, metrics, alarms |
+
+---
+
+## Checklist
+
+- [ ] Dockerfile with multi-stage build
+- [ ] ECR repository with scanOnPush
+- [ ] Secrets in Secrets Manager
+- [ ] ECS task definition with secret references
+- [ ] ALB + HTTPS + health check
+- [ ] Auto-scaling policy configured
+- [ ] CodePipeline from git → build → deploy
+- [ ] CloudWatch dashboard + alarms
+
+---
+
+| Day | Topic |
+|-----|-------|
+| 1 | **Deploy MCP Server on ECS Fargate ✅** |
+| 2 | Agent State with DynamoDB Global Tables |
+| 3 | LLM Caching with ElastiCache + Bedrock |
+| 4 | Serverless Agent with Lambda + Bedrock |
+| 5 | Multi-Region Agent Routing with Route53 |
+| 6 | CI/CD for AI Agents with CodePipeline |
+
+---
+
+*Series: AWS for AI/Agent Developers. Day 1: Deploy an MCP server on ECS Fargate with ALB, Secrets Manager, auto-scaling, and CI/CD pipeline. Full AWS CLI commands included.*

--- a/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate.md
+++ b/src/content/posts/aws-for-ai-agent-developers-deploy-mcp-ecs-fargate.md
@@ -21,17 +21,81 @@ series:
   total: 6
 ---
 
-You built an MCP server. It works on localhost. Now make it accessible to the internet — and to every agent that needs it.
+## Series Overview
 
-ECS Fargate is the sweet spot for serving MCP servers: no EC2 to manage, auto-scaling out of the box, and a built-in load balancer. You ship a Docker image, Fargate does the rest.
+AI agents are powerful, but running them in production is a different game. You need infrastructure that's reliable, scalable, and secure — and that's where AWS comes in.
 
-This post deploys a GitHub Issue Manager MCP server onto AWS ECS Fargate, with:
+This series teaches you **how to build production-grade infrastructure for AI agents using AWS services**. Each day covers one piece of the puzzle: deploying models, managing state, caching, routing traffic, and automating deployments.
 
-- Application Load Balancer (HTTPS + WebSocket for SSE transport)
-- Auto-scaling based on request count
-- Secrets Manager for GitHub tokens
-- ECR for Docker image storage
-- CI/CD via CodePipeline
+### The Big Picture — What We're Building
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Production AI Agent Architecture                  │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐      │
+│  │   Agent  │    │   Agent  │    │   Agent  │    │   Agent  │      │
+│  │  (Team A)│    │  (Team B)│    │  (Team C)│    │  (Team D)│      │
+│  └────┬─────┘    └────┬─────┘    └────┬─────┘    └────┬─────┘      │
+│       │               │               │               │            │
+│       └───────────────┼───────────────┼───────────────┘            │
+│                       │               │                            │
+│              ┌────────▼───────────────▼────────┐                   │
+│              │     Route53 + CloudFront         │  ◄── Day 5       │
+│              │  (Global traffic routing + CDN)  │                   │
+│              └────────┬───────────────┬────────┘                   │
+│                       │               │                            │
+│              ┌────────▼───────────────▼────────┐                   │
+│              │       ALB (Load Balancer)        │  ◄── Day 1       │
+│              └────────┬───────────────┬────────┘                   │
+│                       │               │                            │
+│  ┌────────────────────┼───────────────┼────────────────────┐       │
+│  │         ┌──────────▼───────┐ ┌────▼───────────┐        │       │
+│  │         │  ECS Fargate     │ │  Lambda +      │        │       │
+│  │         │  (Containerized) │ │  Bedrock       │  ◄── Day 1,4  │
+│  │         │  MCP Server      │ │  (Serverless)  │        │       │
+│  │         └──────────┬───────┘ └────┬───────────┘        │       │
+│  │                    │              │                    │       │
+│  │  ┌─────────────────┼──────────────┼────────────────┐   │       │
+│  │  │         ┌───────▼──────┐ ┌────▼────────┐       │   │       │
+│  │  │         │  DynamoDB   │ │  ElastiCache │       │   │       │
+│  │  │         │  (State,    │ │  (Cache,     │       │   │       │
+│  │  │         │  Sessions)  │ │  Bedrock)    │       │   │       │
+│  │  │         └─────────────┘ └─────────────┘       │   │       │
+│  │  └───────────────────────────────────────────────┘   │       │
+│  └──────────────────────────────────────────────────────┘       │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐ │
+│  │  CI/CD Pipeline (CodePipeline + CodeBuild)          ◄── Day 6│ │
+│  │  Git push → Build Docker → Push ECR → Deploy ECS             │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Series Roadmap
+
+| Day | Chủ đề | AWS Services | What you learn |
+|-----|--------|-------------|----------------|
+| 1 | **Deploy MCP Server on ECS Fargate** | ECS, ECR, ALB, Secrets Manager | Containerize + deploy your first agent server with HTTPS, secrets, and auto-scaling |
+| 2 | **Agent State with DynamoDB** | DynamoDB Global Tables, DAX | Store conversation history, session state, and handle multi-region replication |
+| 3 | **LLM Caching with ElastiCache + Bedrock** | ElastiCache (Redis), Bedrock | Semantic caching, prompt caching with Bedrock, reduce latency and cost |
+| 4 | **Serverless Agent with Lambda + Bedrock** | Lambda, API Gateway, Bedrock, Step Functions | Build agents without managing servers — Lambda orchestrates Bedrock calls |
+| 5 | **Multi-Region Routing with Route53** | Route53, CloudFront, Global Accelerator | Global traffic routing, failover, latency-based routing for agents |
+| 6 | **CI/CD for AI Agents** | CodePipeline, CodeBuild, ECR, ECS | Automated deployment pipeline — ship agent updates with zero downtime |
+
+Each day builds on the previous one. By day 6, you'll have a complete production infrastructure for any AI agent.
+
+---
+
+## Day 1: Deploy an MCP Server on ECS Fargate
+
+Your MCP server works on localhost. Now make it accessible to the internet — and to every agent that needs it.
+
+ECS Fargate is the sweet spot: no EC2 to manage, auto-scaling out of the box, and a built-in load balancer. You ship a Docker image, Fargate does the rest.
+
+### What we deploy today:
 
 ```
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
@@ -45,6 +109,15 @@ This post deploys a GitHub Issue Manager MCP server onto AWS ECS Fargate, with:
                      │  └────────┘ │     │  └──────────┘ │
                      └──────────────┘     └──────────────┘
 ```
+
+**Step by step:**
+1. Package the MCP server as a Docker container
+2. Push it to ECR (private Docker registry)
+3. Store secrets (GitHub tokens) in AWS Secrets Manager
+4. Create an ECS Fargate cluster and task definition
+5. Set up an ALB with HTTPS to route traffic
+6. Configure auto-scaling
+7. Wire up CI/CD so future deployments are automatic
 
 ---
 


### PR DESCRIPTION
## AWS for AI/Agent Developers — Day 1: Deploy MCP Server on ECS Fargate

### Nội dung:
- **Dockerize MCP server**: multi-stage build, non-root user, health check
- **ECR**: private Docker registry with vulnerability scanning
- **Secrets Manager**: inject GitHub token + SSE shared secret at runtime, never bake into image
- **ECS Fargate**: cluster with FARGATE_SPOT (cost saving), task definition with secret references
- **ALB**: HTTPS termination, health check on /health, private subnets
- **Auto-scaling**: target tracking on ALB request count per target (2-20 tasks)
- **CI/CD**: CodePipeline + CodeBuild — git push → build → ECS deploy
- **Monitoring**: CloudWatch dashboard (CPU, memory, request count, error rate, p95 latency)
- **Cost breakdown**: ~$69/mo full stack, ~$50/mo with FARGATE_SPOT

### New series: AWS for AI/Agent Developers
| Day | Topic |
|-----|-------|
| 1 | Deploy MCP Server on ECS Fargate ✅ |
| 2 | Agent State with DynamoDB Global Tables |
| 3 | LLM Caching with ElastiCache + Bedrock |
| 4 | Serverless Agent with Lambda + Bedrock |
| 5 | Multi-Region Agent Routing with Route53 |
| 6 | CI/CD for AI Agents with CodePipeline |

⚠️ **Do not auto-merge**